### PR TITLE
Copy clean version of Vega-lite specification

### DIFF
--- a/src/vlplot/vlplot.js
+++ b/src/vlplot/vlplot.js
@@ -228,6 +228,9 @@ angular.module('vlui')
         var view;
         scope.$watch('chart.vlSpec', function() {
           var spec = scope.chart.vgSpec = getVgSpec();
+          if (!scope.chart.cleanSpec) {
+            scope.chart.cleanSpec = vl.Encoding.fromSpec(scope.chart.vlSpec).toSpec(true);
+          }
           render(spec);
         }, true);
 

--- a/src/vlplotgroup/vlplotgroup.html
+++ b/src/vlplotgroup/vlplotgroup.html
@@ -23,10 +23,10 @@
       <div class="drop-container">
         <div class="popup-menu popup-command no-shrink dev-tool">
           <a class="command debug" ui-zeroclip zeroclip-model="chart.shorthand">Copy Vls</a>
-          <a class="command debug" ui-zeroclip zeroclip-model="chart.vlSpec | compactJSON">Copy Vl</a>
+          <a class="command debug" ui-zeroclip zeroclip-model="chart.cleanSpec | compactJSON">Copy Vl</a>
           <a class="command debug" ui-zeroclip zeroclip-model="chart.vgSpec | compactJSON">Copy Vg</a>
           <a class="command debug"
-            ng-href="{{ {type:'vl', encoding: chart.vlSpec} | reportUrl }}"
+            ng-href="{{ {type:'vl', encoding: chart.cleanSpec} | reportUrl }}"
             target="_blank">Report Bad Render</a>
           <a ng-click="showFeature=!showFeature" class="command debug">{{chart.score}}</a>
           <div ng-repeat="f in chart.scoreFeatures track by f.reason">


### PR DESCRIPTION
fixes #16 - copy clean version of Vega-lite specification instead of the full, messy one. 

For example, metadata under `_info` would be eliminated.  
