### PR TITLE
Fix scrollbar rendering glitches

### DIFF
--- a/src/vlplotgroup/vlplotgroup.scss
+++ b/src/vlplotgroup/vlplotgroup.scss
@@ -93,6 +93,7 @@
   overflow: hidden;
   text-align: center;
   display: flex;
+  position: relative;
 
   .vis.fit {
     width:100%;
@@ -106,10 +107,16 @@
   .vis.overflow {
     //cursor: pointer;
     width: 100%;
-    overflow: hidden;
+    @extend .persist-scroll;
+
+    &::-webkit-scrollbar-thumb {
+      background-color: rgba(0, 0, 0, 0);
+    }
+    overflow: scroll;
     &.scroll {
-      @extend .persist-scroll;
-      overflow: scroll;
+      &::-webkit-scrollbar-thumb {
+        background-color: rgba(0, 0, 0, 0.5);
+      }
     }
   }
 }


### PR DESCRIPTION
Make the scroll always enabled but having transparent `-webkit-scroll-bar-thumb` for clean visual.

This will prevent rendering glitches and fixes https://github.com/uwdata/voyager/issues/132
However, the scrolljacking (https://github.com/uwdata/voyager/issues/144) is still there.
