### PR TITLE
better deal with scroll jacking

### DIFF
--- a/src/fieldinfo/fieldinfo.js
+++ b/src/fieldinfo/fieldinfo.js
@@ -40,7 +40,7 @@ angular.module('vlui')
         scope.func = function(field) {
           return field.aggregate || field.timeUnit ||
             (field.bin && 'bin') ||
-            field._aggr || field._timeUnit ||
+            field._aggregate || field._timeUnit ||
             (field._bin && 'bin') || (field._any && 'auto');
         };
 

--- a/src/vlplotgroup/vlplotgroup.scss
+++ b/src/vlplotgroup/vlplotgroup.scss
@@ -86,7 +86,6 @@
 }
 
 .vl-plot-wrapper {
-  @extend .persist-scroll;
   min-height: 150px;
   max-height: 330px;
   min-width: 250px;
@@ -110,6 +109,9 @@
     &.scroll {
       @extend .persist-scroll;
       overflow: scroll;
+      /* when-scroll add negative margin equal to the scrollbar size (in index.scss) */
+      margin-right: -11px;
+      margin-bottom: -11px;
     }
   }
 }

--- a/src/vlplotgroup/vlplotgroup.scss
+++ b/src/vlplotgroup/vlplotgroup.scss
@@ -93,7 +93,6 @@
   overflow: hidden;
   text-align: center;
   display: flex;
-  position: relative;
 
   .vis.fit {
     width:100%;
@@ -107,16 +106,10 @@
   .vis.overflow {
     //cursor: pointer;
     width: 100%;
-    @extend .persist-scroll;
-
-    &::-webkit-scrollbar-thumb {
-      background-color: rgba(0, 0, 0, 0);
-    }
-    overflow: scroll;
+    overflow: hidden;
     &.scroll {
-      &::-webkit-scrollbar-thumb {
-        background-color: rgba(0, 0, 0, 0.5);
-      }
+      @extend .persist-scroll;
+      overflow: scroll;
     }
   }
 }


### PR DESCRIPTION
address https://github.com/uwdata/voyager/issues/144 and fixes https://github.com/uwdata/voyager/issues/167
- bring back 0.5 delay before enable scrolling
- when scroll is enabled, add negative `margin-right` and `margin-bottom` to prevent re-layout

This is definitely much better than earlier. The question is whether we want to show a toast at 0.5 asking user to click to enable scroll instead of enabling scroll directly.

Maybe we spend time on something else first?
(Actually, after we migrate to vega 2, we can choose to show only top 10 items and interact directly with chart while keeping the axis in the view.)
