### PR TITLE
Keep dataset window on-screen when it opens

### DIFF
--- a/src/dataset/datasetselector.js
+++ b/src/dataset/datasetselector.js
@@ -31,8 +31,8 @@ angular.module('vlui')
 
         var funcsPopup = new Drop({
           content: element.find('.popup-new-dataset')[0],
-          target: element.find('.open-dataset-popup')[0],
-          position: 'center center',
+          target: document.body,
+          position: 'top left',
           openOn: false
         });
 


### PR DESCRIPTION
This anchors the data load window to the top-left of the surrounding document's body

I considered centering it in the body, like the bookmarks window, but without an overlay behind it it did not look great. consider this a first step; I'm also working on altering the layout of the drop so that it is easier to work with and easier to support new data load methods.

See #72

![image](https://cloud.githubusercontent.com/assets/442115/10112936/6415c49c-63ad-11e5-8535-21336fcdece2.png)
