### PR TITLE
Convert all dependency injection to preferred array notation

### DIFF
--- a/src/alerts/alerts.service.js
+++ b/src/alerts/alerts.service.js
@@ -1,7 +1,8 @@
 'use strict';
 
-angular.module('vlui')
-  .service('Alerts', function($timeout, _) {
+angular.module('vlui').service('Alerts', [
+  '$timeout', '_',
+  function($timeout, _) {
     var Alerts = {};
 
     Alerts.alerts = [];
@@ -22,4 +23,5 @@ angular.module('vlui')
     };
 
     return Alerts;
-  });
+  }
+]);

--- a/src/bookmarklist/bookmarklist.js
+++ b/src/bookmarklist/bookmarklist.js
@@ -6,8 +6,9 @@
  * @description
  * # bookmarkList
  */
-angular.module('vlui')
-  .directive('bookmarkList', function (Bookmarks, consts) {
+angular.module('vlui').directive('bookmarkList', [
+  'Bookmarks', 'consts',
+  function (Bookmarks, consts) {
     return {
       templateUrl: 'bookmarklist/bookmarklist.html',
       restrict: 'E',
@@ -23,4 +24,5 @@ angular.module('vlui')
         scope.consts = consts;
       }
     };
-  });
+  }
+]);

--- a/src/bookmarks/bookmarks.service.js
+++ b/src/bookmarks/bookmarks.service.js
@@ -7,8 +7,9 @@
  * # Bookmarks
  * Service in the vlui.
  */
-angular.module('vlui')
-  .service('Bookmarks', function(_, vl, localStorageService, Logger, Dataset) {
+angular.module('vlui').service('Bookmarks', [
+  '_', 'vl', 'localStorageService', 'Logger', 'Dataset',
+  function(_, vl, localStorageService, Logger, Dataset) {
     var Bookmarks = function() {
       this.dict = {};
       this.length = 0;
@@ -81,4 +82,5 @@ angular.module('vlui')
     };
 
     return new Bookmarks();
-  });
+  }
+]);

--- a/src/config/config.service.js
+++ b/src/config/config.service.js
@@ -2,8 +2,9 @@
 
 // Service for the spec config.
 // We keep this separate so that changes are kept even if the spec changes.
-angular.module('vlui')
-  .factory('Config', function(vl, _) {
+angular.module('vlui').factory('Config', [
+  'vl', '_',
+  function(vl, _) {
     var Config = {};
 
     Config.schema = vl.schema.schema.properties.config;
@@ -45,4 +46,5 @@ angular.module('vlui')
     };
 
     return Config;
-  });
+  }
+]);

--- a/src/dataset/addmyriadataset.js
+++ b/src/dataset/addmyriadataset.js
@@ -6,8 +6,9 @@
  * @description
  * # addMyriaDataset
  */
-angular.module('vlui')
-  .directive('addMyriaDataset', function ($http, Dataset, consts) {
+angular.module('vlui').directive('addMyriaDataset', [
+  '$http', 'Dataset', 'consts',
+  function ($http, Dataset, consts) {
     return {
       templateUrl: 'dataset/addmyriadataset.html',
       restrict: 'E',
@@ -46,4 +47,5 @@ angular.module('vlui')
         };
       }
     };
-  });
+  }
+]);

--- a/src/dataset/addurldataset.js
+++ b/src/dataset/addurldataset.js
@@ -6,8 +6,9 @@
  * @description
  * # addUrlDataset
  */
-angular.module('vlui')
-  .directive('addUrlDataset', function (Dataset, Logger) {
+angular.module('vlui').directive('addUrlDataset', [
+  'Dataset', 'Logger',
+  function (Dataset, Logger) {
     return {
       templateUrl: 'dataset/addurldataset.html',
       restrict: 'E',
@@ -32,4 +33,5 @@ angular.module('vlui')
         };
       }
     };
-  });
+  }
+]);

--- a/src/dataset/dataset.service.js
+++ b/src/dataset/dataset.service.js
@@ -74,8 +74,9 @@ function getNameMap(dataschema) {
   }, {});
 }
 
-angular.module('vlui')
-  .factory('Dataset', function($http, $q, Alerts, _, dl, vl) {
+angular.module('vlui').factory('Dataset', [
+  '$http', '$q', 'Alerts', '_', 'dl', 'vl',
+  function($http, $q, Alerts, _, dl, vl) {
     var Dataset = {};
 
     Dataset.datasets = datasets;
@@ -207,4 +208,5 @@ angular.module('vlui')
   };
 
   return Dataset;
-});
+}
+]);

--- a/src/dataset/datasetselector.js
+++ b/src/dataset/datasetselector.js
@@ -1,7 +1,8 @@
 'use strict';
 
-angular.module('vlui')
-  .directive('datasetSelector', function(Drop, Dataset, Config, Logger) {
+angular.module('vlui').directive('datasetSelector', [
+  'Drop', 'Dataset', 'Config', 'Logger',
+  function(Drop, Dataset, Config, Logger) {
     return {
       templateUrl: 'dataset/datasetselector.html',
       restrict: 'E',
@@ -43,4 +44,5 @@ angular.module('vlui')
         });
       }
     };
-  });
+  }
+]);

--- a/src/dataset/pastedataset.js
+++ b/src/dataset/pastedataset.js
@@ -6,8 +6,9 @@
  * @description
  * # pasteDataset
  */
-angular.module('vlui')
-  .directive('pasteDataset', function (Dataset, Alerts, Logger, Config, _, dl) {
+angular.module('vlui').directive('pasteDataset', [
+  'Dataset', 'Alerts', 'Logger', 'Config', '_', 'dl',
+  function (Dataset, Alerts, Logger, Config, _, dl) {
     return {
       templateUrl: 'dataset/pastedataset.html',
       restrict: 'E',
@@ -40,4 +41,5 @@ angular.module('vlui')
         };
       }
     };
-  });
+  }
+]);

--- a/src/fieldinfo/fieldinfo.js
+++ b/src/fieldinfo/fieldinfo.js
@@ -6,8 +6,9 @@
  * @description
  * # fieldInfo
  */
-angular.module('vlui')
-  .directive('fieldInfo', function (Dataset, Drop, vl, consts) {
+angular.module('vlui').directive('fieldInfo', [
+  'Dataset', 'Drop', 'vl', 'consts',
+  function (Dataset, Drop, vl, consts) {
     return {
       templateUrl: 'fieldinfo/fieldinfo.html',
       restrict: 'E',
@@ -66,4 +67,5 @@ angular.module('vlui')
         });
       }
     };
-  });
+  }
+]);

--- a/src/filters/compactjson/compactjson.filter.js
+++ b/src/filters/compactjson/compactjson.filter.js
@@ -1,8 +1,9 @@
 'use strict';
 
-angular.module('vlui')
-  .filter('compactJSON', function() {
+angular.module('vlui').filter('compactJSON', [
+  function() {
     return function(input) {
       return JSON.stringify(input, null, '  ', 80);
     };
-  });
+  }
+]);

--- a/src/filters/encodeuri/encodeuri.filter.js
+++ b/src/filters/encodeuri/encodeuri.filter.js
@@ -8,9 +8,10 @@
  * # encodeUri
  * Filter in the vega-lite-ui.
  */
-angular.module('vlui')
-  .filter('encodeURI', function () {
+angular.module('vlui').filter('encodeURI', [
+  function () {
     return function (input) {
       return window.encodeURI(input);
     };
-  });
+  }
+]);

--- a/src/filters/reporturl/reporturl.filter.js
+++ b/src/filters/reporturl/reporturl.filter.js
@@ -8,8 +8,9 @@
  * # reportUrl
  * Filter in the facetedviz.
  */
-angular.module('vlui')
-  .filter('reportUrl', function (compactJSONFilter, _, consts) {
+angular.module('vlui').filter('reportUrl', [
+  'compactJSONFilter', '_', 'consts',
+  function (compactJSONFilter, _, consts) {
     function voyagerReport(params) {
       var url = 'https://docs.google.com/forms/d/1T9ZA14F3mmzrHR7JJVUKyPXzrMqF54CjLIOjv2E7ZEM/viewform?';
 
@@ -57,4 +58,5 @@ angular.module('vlui')
     }
 
     return consts.appId === 'voyager' ? voyagerReport : vluiReport;
-  });
+  }
+]);

--- a/src/filters/scaletype/scaletype.filter.js
+++ b/src/filters/scaletype/scaletype.filter.js
@@ -1,7 +1,7 @@
 'use strict';
 
-angular.module('vlui')
-  .filter('scaleType', function() {
+angular.module('vlui').filter('scaleType', [
+  function() {
     return function(input) {
       var scaleTypes = {
         Q: 'Quantitative',
@@ -12,4 +12,5 @@ angular.module('vlui')
 
       return scaleTypes[input];
     };
-  });
+  }
+]);

--- a/src/filters/underscore2space/underscore2space.filter.js
+++ b/src/filters/underscore2space/underscore2space.filter.js
@@ -8,9 +8,10 @@
  * # underscore2space
  * Filter in the vega-lite-ui.
  */
-angular.module('vlui')
-  .filter('underscore2space', function () {
+angular.module('vlui').filter('underscore2space', [
+  function () {
     return function (input) {
       return input ? input.replace(/_+/g, ' ') : '';
     };
-  });
+  }
+]);

--- a/src/index.js
+++ b/src/index.js
@@ -40,7 +40,13 @@ angular.module('vlui', [
       G: 'geo'
     }
   })
-  .config(function (AnalyticsProvider) {
-    AnalyticsProvider
-      .setAccount({ tracker: 'UA-44428446-4', name: 'voyager', trackEvent: true });
-  });
+  .config([
+    'AnalyticsProvider',
+    function (AnalyticsProvider) {
+      AnalyticsProvider.setAccount({
+        tracker: 'UA-44428446-4',
+        name: 'voyager',
+        trackEvent: true
+      });
+    }
+  ]);

--- a/src/logger/logger.service.js
+++ b/src/logger/logger.service.js
@@ -7,8 +7,9 @@
  * # logger
  * Service in the vega-lite-ui.
  */
-angular.module('vlui')
-  .service('Logger', function ($location, $window, consts, Analytics) {
+angular.module('vlui').service('Logger', [
+  '$location', '$window', 'consts', 'Analytics',
+  function ($location, $window, consts, Analytics) {
 
     var service = {};
 
@@ -89,4 +90,5 @@ angular.module('vlui')
     service.logInteraction(service.actions.INITIALIZE, consts.appId);
 
     return service;
-  });
+  }
+]);

--- a/src/vlplot/vlplot.js
+++ b/src/vlplot/vlplot.js
@@ -1,7 +1,8 @@
 'use strict';
 
-angular.module('vlui')
-  .directive('vlPlot', function(vl, vg, $timeout, $q, Dataset, Config, consts, _, $document, Logger, Heap) {
+angular.module('vlui').directive('vlPlot', [
+  'vl', 'vg', '$timeout', '$q', 'Dataset', 'Config', 'consts', '_', '$document', 'Logger', 'Heap',
+  function(vl, vg, $timeout, $q, Dataset, Config, consts, _, $document, Logger, Heap) {
     var counter = 0;
     var MAX_CANVAS_SIZE = 32767/2, MAX_CANVAS_AREA = 268435456/4;
 
@@ -258,4 +259,5 @@ angular.module('vlui')
         });
       }
     };
-  });
+  }
+]);

--- a/src/vlplotgroup/vlplotgroup.js
+++ b/src/vlplotgroup/vlplotgroup.js
@@ -6,8 +6,9 @@
  * @description
  * # visListItem
  */
-angular.module('vlui')
-  .directive('vlPlotGroup', function (Bookmarks, consts, vl, Dataset, Drop, Logger) {
+angular.module('vlui').directive('vlPlotGroup', [
+  'Bookmarks', 'consts', 'vl', 'Dataset', 'Drop', 'Logger',
+  function (Bookmarks, consts, vl, Dataset, Drop, Logger) {
     return {
       templateUrl: 'vlplotgroup/vlplotgroup.html',
       restrict: 'E',
@@ -139,4 +140,5 @@ angular.module('vlui')
         });
       }
     };
-  });
+  }
+]);


### PR DESCRIPTION
Closes #80: using angular array notation for dependency injection will allow the minified code to be successfully loaded and parsed by angular.

Angular documentation reference: https://docs.angularjs.org/guide/di#inline-array-annotation

I tested this by (with vlui bower-linked to voyager) building vlui, changing the `"main"` option in bower.json to be `vlui.min.js`, then re-starting voyager so it would pick up the minified file from bower, and testing that voyager functionality was unaffected.
