### PR TITLE
Use gulp-ng-annotate to auto-annotate dependency names

### DIFF
--- a/gulp/build.js
+++ b/gulp/build.js
@@ -11,17 +11,17 @@ var $ = require('gulp-load-plugins')({
 
 gulp.task('partials', function () {
   return gulp.src([
-	    paths.src + '/**/*.html'
-	  ])
-	  .pipe($.minifyHtml({
-	    empty: true,
-	    spare: true,
-	    quotes: true
-	  }))
-	  .pipe($.angularTemplatecache('templateCacheHtml.js', {
-	    module: 'vlui'
-	  }))
-	  .pipe(gulp.dest(paths.tmp + '/partials/'));
+      paths.src + '/**/*.html'
+    ])
+    .pipe($.minifyHtml({
+      empty: true,
+      spare: true,
+      quotes: true
+    }))
+    .pipe($.angularTemplatecache('templateCacheHtml.js', {
+      module: 'vlui'
+    }))
+    .pipe(gulp.dest(paths.tmp + '/partials/'));
 });
 
 // Root directory
@@ -45,6 +45,10 @@ gulp.task('build', ['partials', 'css'], function() {
     // .pipe(filter('-'+path.join(sourceDirectory, '/**/*.spec.js')))
     .pipe($.plumber())
     .pipe($.sourcemaps.init())
+      .pipe($.ngAnnotate({
+        add: true, // Add dependency annotations
+        single_quotes: true
+      }))
       .pipe($.iife({
         useStrict: false
       }))

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "gulp-karma": "0.0.4",
     "gulp-load-plugins": "^1.0.0-rc",
     "gulp-minify-html": "^1.0.4",
+    "gulp-ng-annotate": "^1.1.0",
     "gulp-plumber": "^1.0.1",
     "gulp-rename": "^1.2.2",
     "gulp-sourcemaps": "^1.5.2",


### PR DESCRIPTION
Closes #85 and fixes #80
