### PR TITLE
Abstract the modal close button into a directive

### DIFF
--- a/src/bookmarklist/bookmarklist.html
+++ b/src/bookmarklist/bookmarklist.html
@@ -1,9 +1,6 @@
-
     <div class="vflex full-width full-height" id="evs">
       <div class="modal-header no-shrink card no-top-margin no-right-margin">
-        <div class="right">
-          <a ng-click="deactivate()" class="right">Close</a>
-        </div>
+        <modal-close-button on-close="logBookmarksClosed()"></modal-close-button>
         <h2 class="no-bottom-margin">Bookmarks ({{ Bookmarks.length }})</h2>
         <a ng-click="Bookmarks.clear()"><i class="fa fa-trash-o"></i> Clear all</a>
       </div>

--- a/src/bookmarklist/bookmarklist.js
+++ b/src/bookmarklist/bookmarklist.js
@@ -12,15 +12,18 @@ angular.module('vlui')
       templateUrl: 'bookmarklist/bookmarklist.html',
       restrict: 'E',
       replace: true,
-      require: '^modal',
       scope: {
         highlighted: '='
       },
       link: function postLink(scope, element, attrs, modalController) {
-        scope.deactivate = function() {
+        // The bookmark list is designed to render within a modal overlay.
+        // Because modal contents are hidden via ng-if, if this link function is
+        // executing it is because the directive is being shown. Log the event:
+        Logger.logInteraction(Logger.actions.BOOKMARK_OPEN);
+        scope.logBookmarksClosed = function() {
           Logger.logInteraction(Logger.actions.BOOKMARK_CLOSE);
-          modalController.close();
         };
+
         scope.Bookmarks = Bookmarks;
         scope.consts = consts;
       }

--- a/src/bookmarklist/bookmarklist.spec.js
+++ b/src/bookmarklist/bookmarklist.spec.js
@@ -22,6 +22,7 @@ describe('Directive: bookmarkList', function () {
   }));
 
   it('requires a parent modal directive', inject(function ($compile) {
+    // This is a side-effect of the modalCloseButton directive inside bookmarkList
     element = angular.element('<bookmark-list></bookmark-list>');
     expect(function() {
       $compile(element)(scope);

--- a/src/modal/modal.spec.js
+++ b/src/modal/modal.spec.js
@@ -46,9 +46,9 @@ describe('Directive: modal', function () {
         scope.$digest();
       }));
 
-      it('shows its contents', inject(function(Modals) {
+      it('shows its contents', function() {
         expect(element.find('h1').length).to.equal(1);
-      }));
+      });
 
       it('hides its contents when closed', inject(function(Modals) {
         expect(element.find('h1').length).to.equal(1);

--- a/src/modal/modalclosebutton.html
+++ b/src/modal/modalclosebutton.html
@@ -1,0 +1,3 @@
+<div class="right">
+  <a ng-click="closeModal()" class="right">Close</a>
+</div>

--- a/src/modal/modalclosebutton.js
+++ b/src/modal/modalclosebutton.js
@@ -1,0 +1,27 @@
+'use strict';
+
+/**
+ * @ngdoc directive
+ * @name vlui.directive:modalCloseButton
+ * @description
+ * # modalCloseButton
+ */
+angular.module('vlui')
+  .directive('modalCloseButton', function() {
+    return {
+      templateUrl: 'modal/modalclosebutton.html',
+      restrict: 'E',
+      require: '^modal',
+      scope: {
+        'closeCallback': '&onClose'
+      },
+      link: function(scope, element, attrs, modalController) {
+        scope.closeModal = function() {
+          modalController.close();
+          if (scope.closeCallback) {
+            scope.closeCallback();
+          }
+        };
+      }
+    };
+  });

--- a/src/modal/modalclosebutton.spec.js
+++ b/src/modal/modalclosebutton.spec.js
@@ -1,0 +1,73 @@
+'use strict';
+
+/* global vl:true */
+
+describe('Directive: modalCloseButton', function () {
+  var element,
+    scope;
+
+  beforeEach(module('vlui', function($provide) {
+    // mock vega lite
+    $provide.constant('vl', vl);
+  }));
+
+  beforeEach(inject(function ($rootScope) {
+    scope = $rootScope.$new();
+    scope.active = true;
+  }));
+
+  afterEach(inject(function(Modals) {
+    // Remove any modals registered during the tests
+    Modals.empty();
+  }));
+
+  it('requires a parent modal directive', inject(function ($compile) {
+    element = angular.element('<modal-close-button></modal-close-button>');
+    expect(function() {
+      $compile(element)(scope);
+    }).to.throw;
+    element = angular.element('<modal><modal-close-button></modal-close-button></modal>');
+    expect(function() {
+      $compile(element)(scope);
+    }).not.to.throw;
+  }));
+
+  describe('when parent modal is open', function() {
+    beforeEach(inject(function ($compile, Modals) {
+      // Render modal
+      element = angular.element('<modal id="button-parent"><modal-close-button></modal-close-button></modal>');
+      element = $compile(element)(scope);
+      scope.$digest();
+      // Open modal to render button
+      Modals.open('button-parent');
+      scope.$digest();
+    }));
+
+    it('renders a close link', function() {
+      expect(element.find('a').length).to.equal(1);
+      expect(element.find('a').text()).to.equal('Close');
+    });
+
+    it('closes parent modal when clicked', function() {
+      element.find('a').triggerHandler('click');
+      expect(element.find('a').length).to.equal(0);
+    });
+  });
+
+  it('fires an on-close callback method, if one is provided', inject(function($compile, Modals) {
+    var cbHasFired = false;
+    element = angular.element('<modal id="button-parent"><modal-close-button on-close="someCb()"></modal-close-button></modal>');
+    scope.someCb = function() {
+      cbHasFired = true;
+    };
+    element = $compile(element)(scope);
+    scope.$digest();
+    // Open modal to render button
+    Modals.open('button-parent');
+    scope.$digest();
+    expect(cbHasFired).to.be.false;
+    element.find('a').triggerHandler('click');
+    expect(cbHasFired).to.be.true;
+  }));
+
+});


### PR DESCRIPTION
I made this change while duplicating the modal functionality for the data load modal, submitting it as a separate PR for ease of review.

This also fixes a logging miss where the bookmarks window open event was not being logged

Moving the close button into a directive frees the link function of a modal from itself depending on or interacting with the parent directive's modalController: they can just include a modalCloseButton somewhere in their markup, and the modalCloseButton will handle all the interaction with the parent directive.

The modal close button also provides an interface by which a directive can register a handler that will run when that button is used to close the modal.
