### PR TITLE
Move Add by URL and Add by Paste directives to new modal

### DIFF
--- a/src/dataset/addmyriadataset.html
+++ b/src/dataset/addmyriadataset.html
@@ -3,7 +3,7 @@
   <p>
     Select a dataset from the Myria instance at <code>{{myriaRestUrl}}</code>.
   </p>
-  <form>
+  <form ng-submit="addDataset(myriaDataset)">
 		<ui-select ng-model="$parent.myriaDataset" style="width: 300px" theme="selectize" ng-disabled="disabled" reset-search-input="false">
 	    <ui-select-match placeholder="Select dataset...">{{$select.selected.relationName}}</ui-select-match>
 	    <ui-select-choices id="dataset-name" repeat="dataset in myriaDatasets"
@@ -12,6 +12,6 @@
 	       {{ dataset.userName}}:{{dataset.programName}}:{{dataset.relationName }}
 			</ui-select-choices>
 	  </ui-select>
-    <button type="submit" ng-click="addFromMyria(myriaDataset)">Add dataset</button>
+    <button type="submit">Add dataset</button>
   </form>
 </div>

--- a/src/dataset/addmyriadataset.js
+++ b/src/dataset/addmyriadataset.js
@@ -11,13 +11,21 @@ angular.module('vlui')
     return {
       templateUrl: 'dataset/addmyriadataset.html',
       restrict: 'E',
+      require: '?^^modal',
       replace: true,
-      scope: false,  // use scope from datasetSelector
-      link: function postLink(scope/*, element, attrs*/) {
+      scope: true,
+      link: function postLink(scope, element, attrs, modalController) {
+        // If this directive occurs within a a modal, give ourselves a way to close
+        // that modal once the add button has been clicked
+        function closeModal() {
+          if (modalController) {
+            modalController.close();
+          }
+        }
+
+        // Initialize scope variables
         scope.myriaRestUrl = consts.myriaRest;
-
         scope.myriaDatasets = [];
-
         scope.myriaDataset = null;
 
         scope.loadDatasets = function(query) {
@@ -27,8 +35,7 @@ angular.module('vlui')
             });
         };
 
-        // need to give this a unique name because we share the namespace
-        scope.addFromMyria = function(myriaDataset) {
+        scope.addDataset = function(myriaDataset) {
           var dataset = {
             group: 'myria',
             name: myriaDataset.relationName,
@@ -38,11 +45,10 @@ angular.module('vlui')
           };
 
           Dataset.type = 'json';
-          Dataset.dataset = Dataset.add(angular.copy(dataset));
-          scope.datasetChanged();
+          Dataset.dataset = Dataset.add(dataset);
+          Dataset.update(Dataset.dataset);
 
-          scope.myriaDataset = null;
-          scope.doneAdd();
+          closeModal();
         };
       }
     };

--- a/src/dataset/addurldataset.html
+++ b/src/dataset/addurldataset.html
@@ -5,7 +5,7 @@
     Make sure that the formatting is correct and clean the data before adding it to Voyager.
     The added dataset is only visible to you.
   </p>
-  <form>
+  <form ng-submit="addFromUrl(addedDataset)">
     <div class="form-group">
       <label for="dataset-name">Name</label>
       <input ng-model="addedDataset.name" id="dataset-name" type="text"></input>
@@ -17,6 +17,6 @@
         Make sure that you host the file on a server that has <code>Access-Control-Allow-Origin: *</code> set.
       </p>
     </div>
-    <button type="submit" ng-click="addFromUrl(addedDataset)">Add dataset</button>
+    <button type="submit">Add dataset</button>
   </form>
 </div>

--- a/src/dataset/addurldataset.js
+++ b/src/dataset/addurldataset.js
@@ -11,24 +11,33 @@ angular.module('vlui')
     return {
       templateUrl: 'dataset/addurldataset.html',
       restrict: 'E',
+      require: '?^^modal',
       replace: true,
-      scope: false,  // use scope from datasetSelector
-      link: function postLink(scope/*, element, attrs*/) {
+      scope: true,
+      link: function postLink(scope, element, attrs, modalController) {
+        // If this directive occurs within a a modal, give ourselves a way to close
+        // that modal once the add button has been clicked
+        function closeModal() {
+          if (modalController) {
+            modalController.close();
+          }
+        }
+
         // the dataset to add
         scope.addedDataset = {
           group: 'user'
         };
 
-        // need to give this a unique name because we share the namespace
         scope.addFromUrl = function(dataset) {
-          Dataset.dataset = Dataset.add(angular.copy(dataset));
-          scope.datasetChanged();
-
-          scope.addedDataset.name = '';
-          scope.addedDataset.url = '';
-
           Logger.logInteraction(Logger.actions.DATASET_NEW_URL, dataset.url);
-          scope.doneAdd();
+
+          // Register the new dataset
+          Dataset.dataset = Dataset.add(dataset);
+
+          // Fetch & activate the newly-registered dataset
+          Dataset.update(Dataset.dataset);
+
+          closeModal();
         };
       }
     };

--- a/src/dataset/addurldataset.scss
+++ b/src/dataset/addurldataset.scss
@@ -18,7 +18,6 @@
   }
   button {
     margin-top: 1.5em;
-    margin-left: 60px;
     line-height: 15px;
   }
 }

--- a/src/dataset/dataset.service.js
+++ b/src/dataset/dataset.service.js
@@ -8,7 +8,7 @@ function getNameMap(dataschema) {
 }
 
 angular.module('vlui')
-  .factory('Dataset', function($http, $q, Alerts, _, dl, vl, SampleData) {
+  .factory('Dataset', function($http, $q, Alerts, _, dl, vl, SampleData, Config, Logger) {
     var Dataset = {};
 
     // Start with the list of sample datasets
@@ -86,6 +86,8 @@ angular.module('vlui')
     Dataset.update = function(dataset) {
       var updatePromise;
 
+      Logger.logInteraction(Logger.actions.DATASET_CHANGE, dataset.name);
+
       if (dataset.values) {
         updatePromise = $q(function(resolve, reject) {
           // jshint unused:false
@@ -112,6 +114,11 @@ angular.module('vlui')
 
       Dataset.onUpdate.forEach(function(listener) {
         updatePromise = updatePromise.then(listener);
+      });
+
+      // Copy the dataset into the config service once it is ready
+      updatePromise.then(function() {
+        Config.updateDataset(dataset, Dataset.type);
       });
 
       return updatePromise;

--- a/src/dataset/datasetmodal.html
+++ b/src/dataset/datasetmodal.html
@@ -7,6 +7,7 @@
 
     <add-url-dataset></add-url-dataset>
     <paste-dataset></paste-dataset>
+    <add-myria-dataset></add-myria-dataset>
 
   </div>
 </modal>

--- a/src/dataset/datasetmodal.html
+++ b/src/dataset/datasetmodal.html
@@ -1,13 +1,12 @@
 <modal id="dataset-modal">
-  <div class="vflex full-width full-height" id="evs">
-    <div class="modal-header no-shrink card no-top-margin no-right-margin">
-      <modal-close-button></modal-close-button>
-      <h2 class="no-bottom-margin">Add Dataset</h2>
-    </div>
-    <div class="flex-grow-1 scroll-y">
+  <div class="modal-header">
+    <modal-close-button></modal-close-button>
+    <h2 class="no-bottom-margin">Add Dataset</h2>
+  </div>
+  <div class="hflex">
 
-      <paste-dataset></paste-dataset>
+    <add-url-dataset></add-url-dataset>
+    <paste-dataset></paste-dataset>
 
-    </div><!--.flex-grow-1-->
   </div>
 </modal>

--- a/src/dataset/datasetmodal.html
+++ b/src/dataset/datasetmodal.html
@@ -1,0 +1,13 @@
+<modal id="dataset-modal">
+  <div class="vflex full-width full-height" id="evs">
+    <div class="modal-header no-shrink card no-top-margin no-right-margin">
+      <modal-close-button></modal-close-button>
+      <h2 class="no-bottom-margin">Add Dataset</h2>
+    </div>
+    <div class="flex-grow-1 scroll-y">
+
+      <paste-dataset></paste-dataset>
+
+    </div><!--.flex-grow-1-->
+  </div>
+</modal>

--- a/src/dataset/datasetmodal.js
+++ b/src/dataset/datasetmodal.js
@@ -1,0 +1,16 @@
+'use strict';
+
+/**
+ * @ngdoc directive
+ * @name vlui.directive:datasetModal
+ * @description
+ * # datasetModal
+ */
+angular.module('vlui')
+  .directive('datasetModal', function () {
+    return {
+      templateUrl: 'dataset/datasetmodal.html',
+      restrict: 'E',
+      scope: false
+    };
+  });

--- a/src/dataset/datasetselector.html
+++ b/src/dataset/datasetselector.html
@@ -10,7 +10,7 @@
       </div>
       <div class="hflex">
         <add-url-dataset></add-url-dataset>
-        <paste-dataset></paste-dataset>
+        <!-- <paste-dataset></paste-dataset> -->
       </div>
     </div>
   </div>

--- a/src/dataset/datasetselector.html
+++ b/src/dataset/datasetselector.html
@@ -3,15 +3,4 @@
   <select id="dataset-select" ng-model="Dataset.dataset" ng-change="datasetChanged()" ng-options="dataset.name group by dataset.group for dataset in Dataset.datasets track by dataset.id">
     <option value="">Add dataset...</option>
   </select>
-  <div class="drop-container">
-    <div class="popup-menu popup-new-dataset">
-      <div class="right">
-        <a class="fa fa-close" ng-click="doneAdd()"></a>
-      </div>
-      <div class="hflex">
-        <add-url-dataset></add-url-dataset>
-        <!-- <paste-dataset></paste-dataset> -->
-      </div>
-    </div>
-  </div>
 </div>

--- a/src/dataset/datasetselector.js
+++ b/src/dataset/datasetselector.js
@@ -1,13 +1,13 @@
 'use strict';
 
 angular.module('vlui')
-  .directive('datasetSelector', function(Drop, Dataset, Logger) {
+  .directive('datasetSelector', function(Dataset, Modals, Logger) {
     return {
       templateUrl: 'dataset/datasetselector.html',
       restrict: 'E',
       replace: true,
       scope: {},
-      link: function postLink(scope , element/*, attrs*/) {
+      link: function postLink(scope/*, element, attrs*/) {
         scope.Dataset = Dataset;
 
         scope.datasetChanged = function() {
@@ -15,28 +15,12 @@ angular.module('vlui')
             // reset if no dataset has been set
             Dataset.dataset = Dataset.currentDataset;
             Logger.logInteraction(Logger.actions.DATASET_OPEN);
-            funcsPopup.open();
+            Modals.open('dataset-modal');
             return;
           }
 
           Dataset.update(Dataset.dataset);
         };
-
-        scope.doneAdd = function() {
-          funcsPopup.close();
-        };
-
-        var funcsPopup = new Drop({
-          content: element.find('.popup-new-dataset')[0],
-          target: element.find('.open-dataset-popup')[0],
-          position: 'right top',
-          openOn: false
-        });
-
-        scope.$on('$destroy', function() {
-          funcsPopup.destroy();
-          funcsPopup = null;
-        });
       }
     };
   });

--- a/src/dataset/datasetselector.js
+++ b/src/dataset/datasetselector.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('vlui')
-  .directive('datasetSelector', function(Drop, Dataset, Config, Logger) {
+  .directive('datasetSelector', function(Drop, Dataset, Logger) {
     return {
       templateUrl: 'dataset/datasetselector.html',
       restrict: 'E',
@@ -19,11 +19,7 @@ angular.module('vlui')
             return;
           }
 
-          Logger.logInteraction(Logger.actions.DATASET_CHANGE, Dataset.dataset.name);
-
-          Dataset.update(Dataset.dataset).then(function() {
-            Config.updateDataset(Dataset.dataset, Dataset.type);
-          });
+          Dataset.update(Dataset.dataset);
         };
 
         scope.doneAdd = function() {

--- a/src/dataset/pastedataset.html
+++ b/src/dataset/pastedataset.html
@@ -1,10 +1,3 @@
-<div class="vflex full-width full-height" id="evs">
-  <div class="modal-header no-shrink card no-top-margin no-right-margin">
-    <modal-close-button></modal-close-button>
-    <h2 class="no-bottom-margin">Add Dataset</h2>
-  </div>
-  <div class="flex-grow-1 scroll-y">
-
 <div class="paste-data">
   <h3>Paste raw data</h3>
   <p>
@@ -27,7 +20,4 @@
     </div>
     <button type="submit">Add data</button>
   </form>
-</div>
-
-  </div><!--.flex-grow-1-->
 </div>

--- a/src/dataset/pastedataset.html
+++ b/src/dataset/pastedataset.html
@@ -1,17 +1,33 @@
+<div class="vflex full-width full-height" id="evs">
+  <div class="modal-header no-shrink card no-top-margin no-right-margin">
+    <modal-close-button></modal-close-button>
+    <h2 class="no-bottom-margin">Add Dataset</h2>
+  </div>
+  <div class="flex-grow-1 scroll-y">
+
 <div class="paste-data">
   <h3>Paste raw data</h3>
   <p>
     Paste data in <a href="https://en.wikipedia.org/wiki/Comma-separated_values">CSV</a> format. Please include a header with field names.
   </p>
 
-  <form>
-  	<div class="form-group">
+  <form ng-submit="addDataset()">
+    <div class="form-group">
       <label for="dataset-name">Name</label>
-      <input ng-model="datasetName" id="dataset-name" type="name"></input>
+      <input type="name"
+        ng-model="datasetName"
+        id="dataset-name"
+        required></input>
     </div>
     <div class="form-group">
-    	<textarea ng-model="data"></textarea>
+      <textarea ng-model="data"
+        ng-model-options="{ updateOn: 'default blur', debounce: { 'default': 17, 'blur': 0 }}"
+        required>
+      </textarea>
     </div>
-  	<button type="submit" ng-click="addPasted()">Add data</button>
+    <button type="submit">Add data</button>
   </form>
+</div>
+
+  </div><!--.flex-grow-1-->
 </div>

--- a/src/dataset/pastedataset.spec.js
+++ b/src/dataset/pastedataset.spec.js
@@ -12,7 +12,7 @@ describe('Directive: pasteDataset', function () {
     scope = $rootScope.$new();
   }));
 
-  it('should show correct form', inject(function ($compile) {
+  it.skip('should show correct form', inject(function ($compile) {
     element = angular.element('<paste-dataset></paste-dataset>');
     element = $compile(element)(scope);
 

--- a/src/dataset/pastedataset.spec.js
+++ b/src/dataset/pastedataset.spec.js
@@ -12,7 +12,7 @@ describe('Directive: pasteDataset', function () {
     scope = $rootScope.$new();
   }));
 
-  it.skip('should show correct form', inject(function ($compile) {
+  it('should show correct form', inject(function ($compile) {
     element = angular.element('<paste-dataset></paste-dataset>');
     element = $compile(element)(scope);
 

--- a/src/modal/modalclosebutton.js
+++ b/src/modal/modalclosebutton.js
@@ -11,7 +11,7 @@ angular.module('vlui')
     return {
       templateUrl: 'modal/modalclosebutton.html',
       restrict: 'E',
-      require: '^modal',
+      require: '^^modal',
       scope: {
         'closeCallback': '&onClose'
       },


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/442115/10296297/45489a72-6b95-11e5-924e-aeec9881007e.png)

Some styling TODO and it won't reflect Jim's mockup until tomorrow, but with this PR the new-style modal will be used for all data load purposes.

All actual data setting is now done by the `Dataset` service, so data load directives no longer need to (or should) share a scope.
