### PR TITLE
Organize the dataset add modal with a tab directive

### DIFF
--- a/src/dataset/addmyriadataset.html
+++ b/src/dataset/addmyriadataset.html
@@ -1,5 +1,4 @@
 <div class="add-myria-dataset">
-	<h3>Add a dataset from Myria</h3>
   <p>
     Select a dataset from the Myria instance at <code>{{myriaRestUrl}}</code>.
   </p>

--- a/src/dataset/addurldataset.html
+++ b/src/dataset/addurldataset.html
@@ -1,5 +1,4 @@
 <div class="add-url-dataset">
-  <h3>Add a dataset from URL</h3>
   <p>
     Add the name of the dataset and the URL to a <b>JSON</b> or <b>CSV</b> (with header) file.
     Make sure that the formatting is correct and clean the data before adding it to Voyager.

--- a/src/dataset/datasetmodal.html
+++ b/src/dataset/datasetmodal.html
@@ -1,13 +1,19 @@
 <modal id="dataset-modal">
   <div class="modal-header">
     <modal-close-button></modal-close-button>
-    <h2 class="no-bottom-margin">Add Dataset</h2>
+    <h2>Add Dataset</h2>
   </div>
-  <div class="hflex">
 
-    <add-url-dataset></add-url-dataset>
-    <paste-dataset></paste-dataset>
-    <add-myria-dataset></add-myria-dataset>
+  <tabset>
+    <tab heading="From URL">
+      <add-url-dataset></add-url-dataset>
+    </tab>
+    <tab heading="Paste Raw Data">
+      <paste-dataset></paste-dataset>
+    </tab>
+    <tab heading="From Myria">
+      <add-myria-dataset></add-myria-dataset>
+    </tab>
+  </tabset>
 
-  </div>
 </modal>

--- a/src/dataset/pastedataset.html
+++ b/src/dataset/pastedataset.html
@@ -1,5 +1,4 @@
 <div class="paste-data">
-  <h3>Paste raw data</h3>
   <p>
     Paste data in <a href="https://en.wikipedia.org/wiki/Comma-separated_values">CSV</a> format. Please include a header with field names.
   </p>

--- a/src/tabs/tab.html
+++ b/src/tabs/tab.html
@@ -1,0 +1,1 @@
+<div ng-if="active" ng-transclude></div>

--- a/src/tabs/tab.js
+++ b/src/tabs/tab.js
@@ -1,0 +1,24 @@
+'use strict';
+
+/**
+ * @ngdoc directive
+ * @name vlui.directive:tab
+ * @description
+ * # tab
+ */
+angular.module('vlui')
+  .directive('tab', function() {
+    return {
+      templateUrl: 'tabs/tab.html',
+      restrict: 'E',
+      require: '^^tabset',
+      replace: true,
+      transclude: true,
+      scope: {
+        heading: '@'
+      },
+      link: function(scope, element, attrs, tabsetController) {
+        tabsetController.addTab(scope);
+      }
+    };
+  });

--- a/src/tabs/tab.scss
+++ b/src/tabs/tab.scss
@@ -1,0 +1,23 @@
+.tab-container {
+  .tab {
+    display: inline-block;
+    padding: 5px 10px;
+    margin-right: 5px;
+    margin-bottom: -1px;
+    // Top two corners rounded
+    border-radius: 3px 3px 0 0;
+    border: 1px solid #aaa;
+
+    &.active {
+      font-weight: bold;
+      border-color: #888;
+      border-bottom: 1px solid white;
+    }
+  }
+
+  .tab-contents {
+    padding: 10px;
+    border: 1px solid #888;
+    border-radius: 0 3px 3px 3px;
+  }
+}

--- a/src/tabs/tabset.html
+++ b/src/tabs/tabset.html
@@ -1,0 +1,11 @@
+<div class="tab-container">
+  <div>
+      <a href=""
+        class="tab" ng-repeat="tab in tabset.tabs"
+        ng-class="{'active': tab.active}"
+        ng-click="tabset.showTab(tab)">
+        {{tab.heading}}
+      </a>
+  </div>
+  <div class="tab-contents" ng-transclude></div>
+</div>

--- a/src/tabs/tabset.js
+++ b/src/tabs/tabset.js
@@ -1,0 +1,39 @@
+'use strict';
+
+/**
+ * @ngdoc directive
+ * @name vlui.directive:tabset
+ * @description
+ * # tabset
+ */
+angular.module('vlui')
+  .directive('tabset', function() {
+    return {
+      templateUrl: 'tabs/tabset.html',
+      restrict: 'E',
+      transclude: true,
+
+      // Interface for tabs to register themselves
+      controller: function() {
+        var self = this;
+
+        this.tabs = [];
+
+        this.addTab = function(tabScope) {
+          // First tab is always auto-activated; others auto-deactivated
+          tabScope.active = self.tabs.length === 0;
+          self.tabs.push(tabScope);
+        };
+
+        this.showTab = function(selectedTab) {
+          self.tabs.forEach(function(tab) {
+            // Activate the selected tab, deactivate all others
+            tab.active = tab === selectedTab;
+          });
+        };
+      },
+
+      // Expose controller to templates as "tabset"
+      controllerAs: 'tabset'
+    };
+  });


### PR DESCRIPTION
![modal](https://cloud.githubusercontent.com/assets/442115/10324659/554d1e42-6c59-11e5-8cb3-9da6ee64f4f1.gif)

This implements the tab directive approach @vlandham originally proposed to organize and simplify the layout of the modal directive. I spent a bit of time experimenting with the tabs on the side, as we had it in the original wireframe, and decided the tabs on the top were more idiomatic and readily accessible.

See #77 
