### PR TITLE
Only use customized JSON3-compactstringify within compactJSON filter

### DIFF
--- a/gulp/build.js
+++ b/gulp/build.js
@@ -30,6 +30,8 @@ var rootDirectory = path.resolve('./');
 var sourceDirectory = path.join(rootDirectory, './src');
 
 var sourceFiles = [
+  // Start with 3rd-party dependencies
+  path.join(sourceDirectory, '/vendor/**/*.js'),
   // Make sure the module is handled first
   path.join(sourceDirectory, '/index.js'),
   // template cache file

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -15,9 +15,9 @@ var testFiles = [
   // add bind polyfill since Function.prototype.bind is missing from PhantomJS
   './node_modules/phantomjs-polyfill/bind-polyfill.js',
 ].concat(bowerDeps.js).concat([
+  src + '/vendor/*.js',
   src + '/index.js',
   src + '/**/*.js',
-  src + '/vendor/*.js',
   tmp + '/partials/templateCacheHtml.js'
 ]);
 

--- a/src/filters/compactjson/compactjson.filter.js
+++ b/src/filters/compactjson/compactjson.filter.js
@@ -1,8 +1,8 @@
 'use strict';
 
 angular.module('vlui')
-  .filter('compactJSON', function() {
+  .filter('compactJSON', function(JSON3) {
     return function(input) {
-      return JSON.stringify(input, null, '  ', 80);
+      return JSON3.stringify(input, null, '  ', 80);
     };
   });

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,8 @@ angular.module('vlui', [
   .constant('URL', window.URL)
   .constant('Drop', window.Drop)
   .constant('Heap', window.Heap)
+  // Use the customized vendor/json3-compactstringify
+  .constant('JSON3', window.JSON3.noConflict())
   // constants
   .constant('consts', {
     addCount: true, // add count field to Dataset.dataschema


### PR DESCRIPTION
This library was globally overwriting the JSON object on `window`, which significantly decreased the performance of the application in some browsers because the try/catch within the custom code could not be optimized.

Test case: load a ~300kb dataset with 1000 rows, and profile the performance of adding the dataset with customized JSON3 and with the native JSON object.

Before this PR:

![image](https://cloud.githubusercontent.com/assets/442115/10462479/f1e8e4ea-71ac-11e5-8f51-62ac32953d42.png)

Initial dataset parsing time 3.03 seconds

After this PR:

![image](https://cloud.githubusercontent.com/assets/442115/10462318/12d251e2-71ac-11e5-8fb3-fba7a8b84e36.png)

Initial dataset parsing time **1.13 seconds**
