### PR TITLE
Defer debug UI rendering to signficantly improve first-render performance

### DIFF
--- a/src/vlplotgroup/vlplotgroup.html
+++ b/src/vlplotgroup/vlplotgroup.html
@@ -16,42 +16,13 @@
       ></field-info>
     </div>
     <div class="toolbox">
-      <a ng-show="consts.debug && showDebug"
+      <a ng-if="consts.debug && showDebug"
         class="command debug">
-        <i class="fa fa-wrench" ng-click="shCopied=''; vlCopied=''; vgCopied='';"></i>
+        <!-- Mouseover on wrench icon is the trigger to lazy-render the popup -->
+        <i class="fa fa-wrench" ng-click="shCopied=''; vlCopied=''; vgCopied='';"
+          ng-mouseover="initializePopup();"></i>
       </a>
-      <div class="drop-container">
-        <div class="popup-menu popup-command no-shrink dev-tool">
-          <div class="command debug">
-            <span class="debug">Vls</span>
-            <a class="debug" ui-zeroclip zeroclip-copied="shCopied='(Copied)'" zeroclip-model="chart.shorthand">Copy</a>
-            /
-            <a class="debug" ng-click="logCode('VL shorthand', chart.shorthand); shCopied='(Logged)';">Log</a>
-            <span>{{shCopied}}</span>
-          </div>
-          <div class="command debug">
-            <span class="debug">Vl</span>
-            <a class="debug" ui-zeroclip zeroclip-copied="vlCopied='(Copied)'" zeroclip-model="chart.cleanSpec | compactJSON">Copy</a>
-            /
-            <a class="debug" ng-click="logCode('Vega-lite', chart.cleanSpec); vlCopied='(Logged)';">Log</a>
-            <span>{{vlCopied}}</span>
-          </div>
-          <div class="command debug">
-            <span class="debug">Vg</span>
-            <a class="debug" ui-zeroclip zeroclip-copied="vgCopied='(Copied)'" zeroclip-model="chart.vgSpec | compactJSON">Copy</a>
-            /
-            <a class="debug" ng-click="logCode('Vega', chart.vgSpec); vgCopied='(Logged)';">Log</a>
-            <span>{{vgCopied}}</span>
-          </div>
-          <a class="command debug"
-            ng-href="{{ {type:'vl', encoding: chart.cleanSpec} | reportUrl }}"
-            target="_blank">Report Bad Render</a>
-          <a ng-click="showFeature=!showFeature" class="command debug">{{chart.score}}</a>
-          <div ng-repeat="f in chart.scoreFeatures track by f.reason">
-            [{{f.score}}] {{f.reason}}
-          </div>
-        </div>
-      </div>
+      <vl-plot-group-popup ng-if="consts.debug && showDebug && renderPopup"></vl-plot-group-popup>
       <a ng-if="showMarkType"
         class="command disabled">
         <i class="fa fa-font"></i>
@@ -74,7 +45,7 @@
         <small>LOG Y</small>
       </a>
 
-      <a ng-show="showSort && chart.vlSpec && toggleSort.support(chart.vlSpec, Dataset.stats)"
+      <a ng-if="showSort && chart.vlSpec && toggleSort.support(chart.vlSpec, Dataset.stats)"
         class="command" ng-click="toggleSort(chart.vlSpec)"
         >
         <i class="fa sort"

--- a/src/vlplotgroup/vlplotgroup.js
+++ b/src/vlplotgroup/vlplotgroup.js
@@ -54,7 +54,7 @@ angular.module('vlui')
         highlighted: '=',
         expandAction: '&',
       },
-      link: function postLink(scope, element) {
+      link: function postLink(scope) {
         scope.Bookmarks = Bookmarks;
         scope.consts = consts;
         scope.Dataset = Dataset;

--- a/src/vlplotgroup/vlplotgroup.js
+++ b/src/vlplotgroup/vlplotgroup.js
@@ -7,11 +7,16 @@
  * # visListItem
  */
 angular.module('vlui')
-  .directive('vlPlotGroup', function (Bookmarks, consts, vl, Dataset, Drop, Logger) {
+  .directive('vlPlotGroup', function (Bookmarks, consts, vl, Dataset, Logger, _) {
     return {
       templateUrl: 'vlplotgroup/vlplotgroup.html',
       restrict: 'E',
       replace: true,
+      controller: function($scope, $element) {
+        this.getDropTarget = function() {
+          return $element.find('.fa-wrench')[0];
+        };
+      },
       scope: {
         /* pass to vlplot **/
         chart: '=',
@@ -53,6 +58,13 @@ angular.module('vlui')
         scope.Bookmarks = Bookmarks;
         scope.consts = consts;
         scope.Dataset = Dataset;
+
+        // Defer rendering the debug Drop popup until it is requested
+        scope.renderPopup = false;
+        // Use _.once because the popup only needs to be initialized once
+        scope.initializePopup = _.once(function() {
+          scope.renderPopup = true;
+        });
 
         scope.logCode = function(name, value) {
           console.log(name+':\n\n', JSON.stringify(value));
@@ -105,14 +117,6 @@ angular.module('vlui')
         };
         scope.toggleFilterNull.support = vl.Encoding.toggleFilterNullO.support;
 
-        var debugPopup = new Drop({
-          content: element.find('.dev-tool')[0],
-          target: element.find('.fa-wrench')[0],
-          position: 'bottom right',
-          openOn: 'click',
-          constrainToWindow: true
-        });
-
         scope.toggleSortClass = function(vlSpec) {
           var direction = vlSpec && vl.Encoding.toggleSort.direction(vlSpec),
             mode = vlSpec && vl.Encoding.toggleSort.mode(vlSpec);
@@ -135,7 +139,6 @@ angular.module('vlui')
 
         scope.$on('$destroy', function() {
           scope.chart = null;
-          debugPopup.destroy();
         });
       }
     };

--- a/src/vlplotgroup/vlplotgrouppopup.html
+++ b/src/vlplotgroup/vlplotgrouppopup.html
@@ -1,0 +1,32 @@
+<div class="drop-container">
+  <div class="popup-menu popup-command no-shrink dev-tool">
+    <div class="command debug">
+      <span class="debug">Vls</span>
+      <a class="debug" ui-zeroclip zeroclip-copied="shCopied='(Copied)'" zeroclip-model="chart.shorthand">Copy</a>
+      /
+      <a class="debug" ng-click="logCode('VL shorthand', chart.shorthand); shCopied='(Logged)';">Log</a>
+      <span>{{shCopied}}</span>
+    </div>
+    <div class="command debug">
+      <span class="debug">Vl</span>
+      <a class="debug" ui-zeroclip zeroclip-copied="vlCopied='(Copied)'" zeroclip-model="chart.cleanSpec | compactJSON">Copy</a>
+      /
+      <a class="debug" ng-click="logCode('Vega-lite', chart.cleanSpec); vlCopied='(Logged)';">Log</a>
+      <span>{{vlCopied}}</span>
+    </div>
+    <div class="command debug">
+      <span class="debug">Vg</span>
+      <a class="debug" ui-zeroclip zeroclip-copied="vgCopied='(Copied)'" zeroclip-model="chart.vgSpec | compactJSON">Copy</a>
+      /
+      <a class="debug" ng-click="logCode('Vega', chart.vgSpec); vgCopied='(Logged)';">Log</a>
+      <span>{{vgCopied}}</span>
+    </div>
+    <a class="command debug"
+      ng-href="{{ {type:'vl', encoding: chart.cleanSpec} | reportUrl }}"
+      target="_blank">Report Bad Render</a>
+    <a ng-click="showFeature=!showFeature" class="command debug">{{chart.score}}</a>
+    <div ng-repeat="f in chart.scoreFeatures track by f.reason">
+      [{{f.score}}] {{f.reason}}
+    </div>
+  </div>
+</div>

--- a/src/vlplotgroup/vlplotgrouppopup.js
+++ b/src/vlplotgroup/vlplotgrouppopup.js
@@ -1,0 +1,30 @@
+'use strict';
+
+/**
+ * @ngdoc directive
+ * @name vega-lite-ui.directive:visListItem
+ * @description
+ * # visListItem
+ */
+angular.module('vlui')
+  .directive('vlPlotGroupPopup', function (Drop) {
+    return {
+      templateUrl: 'vlplotgroup/vlplotgrouppopup.html',
+      restrict: 'E',
+      require: '^^vlPlotGroup',
+      scope: false,
+      link: function postLink(scope, element, attrs, vlPlotGroupController) {
+        var debugPopup = new Drop({
+          content: element.find('.dev-tool')[0],
+          target: vlPlotGroupController.getDropTarget(),
+          position: 'bottom right',
+          openOn: 'click',
+          constrainToWindow: true
+        });
+
+        scope.$on('$destroy', function() {
+          debugPopup.destroy();
+        });
+      }
+    };
+  });


### PR DESCRIPTION
Steps to reproduce the original issue:
1. Drag-and-drop or paste-load a medium-size dataset (~100 rows)
2. Click "Add Dataset"
3. Mouse over a left-column UI element to trigger chart re-rendering
4. Observe that chart rendering is extremely sluggish

Background:

Currently, the pop-up debug UI for vega lite plots has to be rendered
at the same time as the rest of the debug UI controls, and cannot be
deferred until needed with an `ng-if`, because the Drop requires the
content element to be present.

![image](https://cloud.githubusercontent.com/assets/442115/10466728/cfd94a86-71c3-11e5-95c8-99decc1cf978.png)

While this may not seem like a huge issue, because the debug popup uses
the `compactJSON` filter, this front-loaded rendering of debug UI that
may never be used is a _significant_ bottleneck on render.

Status quo:

![image](https://cloud.githubusercontent.com/assets/442115/10466418/3d441558-71c2-11e5-91a5-0da64bc88456.png)

Initial render takes **8.89 seconds**, much of which is tied up in
compactjson's inefficient serialization and deserialization.

After lazy-initialization of Drop popup contents:

![image](https://cloud.githubusercontent.com/assets/442115/10466085/4b30aa34-71c0-11e5-84d9-4fa07a43f174.png)

Initial render takes **1.33 seconds**

Removing the processing burden of rendering this data, and iteratively
computing the serialized versions of the datasets, will allow the initial
render to complete in up to **14%** of the time it currently takes.

These savings are accomplished by moving the rendering of the Drop,
and the rendering of that drop's contents, into its own directive.
That directive's visibility is controlled via `ng-if`, so it will not
be evaluated until the user mouses over the debug UI for a plot.

This contextual deferred rendering allows us to completely skip all of
the debug UI rendering during the initial render pass, which gets all
the graphs on the page in much less time than they currently take.
