### PR TITLE
Do not deep-watch data property

### DIFF
--- a/src/vlplot/vlplot.js
+++ b/src/vlplot/vlplot.js
@@ -234,7 +234,10 @@ angular.module('vlui')
         }
 
         var view;
-        scope.$watch('chart.vlSpec', function() {
+        scope.$watch(function() {
+          // Omit data property to speed up deep watch
+          return _.omit(scope.chart.vlSpec, 'data');
+        }, function() {
           var spec = scope.chart.vgSpec = getVgSpec();
           if (!scope.chart.cleanSpec) {
             scope.chart.cleanSpec = vl.Encoding.fromSpec(scope.chart.vlSpec).toSpec(true);


### PR DESCRIPTION
It significantly speeds up the runtime of this watcher to omit the data property from the processing; as the data should be immutable, and it is just the configuration that will change, this alteration does not appear to have any impact on voyager or polestar aside from dramatically improving performance.

Before: (note the visible lag)

![watch-with-data](https://cloud.githubusercontent.com/assets/442115/10469215/c5ff5fe2-71d1-11e5-8f2f-bcbdcd649c23.gif)

After:

![watch-without-data](https://cloud.githubusercontent.com/assets/442115/10469214/c5ff3440-71d1-11e5-988d-a32f2853c96e.gif)
