### PR TITLE
Get data object from Config service by reference, not deep clone

### DIFF
--- a/src/config/config.service.js
+++ b/src/config/config.service.js
@@ -17,7 +17,7 @@ angular.module('vlui')
     };
 
     Config.getData = function() {
-      return _.cloneDeep(Config.data);
+      return Config.data;
     };
 
     Config.large = function() {


### PR DESCRIPTION
Previously, any call to `genClusters` incurred a deep clone of the data object. In the case of large datasets (_e.g._ a ~1mb CSV file), this could result in over a second of additional processing, as well as the creation of a very large duplicate object in-memory:

![image](https://cloud.githubusercontent.com/assets/442115/10492615/049d8c66-727b-11e5-9ce7-7d835a9ac5d2.png)

Altering the Config service to return the data object by reference, rather than as a deep clone, reduces the processing needed to the extent that it no longer even shows up on the profiler:

![image](https://cloud.githubusercontent.com/assets/442115/10492663/493c5a50-727b-11e5-91b8-237ec1ba3cdc.png)

The total run time of `genClusters` drops by about a second in this instance.

Because the data should be consistent across all charts, and it is just the chart configuration that will vary on a plot-by-plot basis, passing the data by reference improves both the memory usage and the performance of the data load process.
