### PR TITLE
Move alertMessages directive from Polestar & fix alert display issue

### DIFF
--- a/src/alertmessages/alertmessages.html
+++ b/src/alertmessages/alertmessages.html
@@ -1,0 +1,6 @@
+<div class="alert-box" ng-show="Alerts.alerts.length > 0">
+  <div class="alert-item" ng-repeat="alert in Alerts.alerts">
+    {{ alert.msg }}
+    <a class="close" ng-click="Alerts.closeAlert($index)">&times;</a>
+  </div>
+</div>

--- a/src/alertmessages/alertmessages.js
+++ b/src/alertmessages/alertmessages.js
@@ -1,9 +1,9 @@
 'use strict';
 
-angular.module('polestar')
+angular.module('vlui')
   .directive('alertMessages', function(Alerts) {
     return {
-      templateUrl: 'components/alertmessages/alertmessages.html',
+      templateUrl: 'alertmessages/alertmessages.html',
       restrict: 'E',
       scope: {},
       link: function(scope /*, element, attrs*/) {

--- a/src/alertmessages/alertmessages.js
+++ b/src/alertmessages/alertmessages.js
@@ -1,0 +1,13 @@
+'use strict';
+
+angular.module('polestar')
+  .directive('alertMessages', function(Alerts) {
+    return {
+      templateUrl: 'components/alertmessages/alertmessages.html',
+      restrict: 'E',
+      scope: {},
+      link: function(scope /*, element, attrs*/) {
+        scope.Alerts = Alerts;
+      }
+    };
+  });

--- a/src/alertmessages/alertmessages.spec.js
+++ b/src/alertmessages/alertmessages.spec.js
@@ -6,17 +6,11 @@ describe('Directive: alertMessages', function() {
     scope;
 
   // load the directive's module
-  beforeEach(module('vlui', function($provide) {
-    // Mock the alerts service
-    $provide.value('Alerts', {
-      alerts: [
-        {msg: 'foo'},
-        {msg: 'bar'}
-      ]
-    });
-  }));
+  beforeEach(module('vlui'));
 
-  beforeEach(inject(function($rootScope, $compile) {
+  beforeEach(inject(function($rootScope, $compile, Alerts) {
+    Alerts.add('foo');
+    Alerts.add('bar');
     scope = $rootScope.$new();
     var $el = angular.element('<alert-messages></alert-messages>');
     element = $compile($el)(scope);
@@ -25,9 +19,20 @@ describe('Directive: alertMessages', function() {
 
   it('should show alert messages', function() {
     expect(element.find('.alert-item').length).to.equal(2);
+  });
+
+  it('should display the alert messages', function() {
     // Ignore the close buttons, which use an HTML entity for the close icon
     element.find('a').remove();
     expect(element.find('.alert-item').eq(0).text().trim()).to.equal('foo');
     expect(element.find('.alert-item').eq(1).text().trim()).to.equal('bar');
+  });
+
+  it('should remove a messagea when the close icon is clicked', function() {
+    element.find('.alert-item').eq(0).find('a').triggerHandler('click');
+    scope.$digest();
+    expect(element.find('.alert-item').length).to.equal(1);
+    element.find('a').remove();
+    expect(element.find('.alert-item').eq(0).text().trim()).to.equal('bar');
   });
 });

--- a/src/alertmessages/alertmessages.spec.js
+++ b/src/alertmessages/alertmessages.spec.js
@@ -1,0 +1,32 @@
+'use strict';
+
+describe('Directive: alertMessages', function() {
+
+  // load the directive's module
+  beforeEach(module('polestar'));
+
+  var element,
+    scope;
+
+  beforeEach(module('polestar', function($provide) {
+    var mock = {
+      alerts: [
+        {name: 'foo'},
+        {name: 'bar'}
+      ]
+    };
+    $provide.value('Alerts', mock);
+  }));
+
+  beforeEach(inject(function($rootScope) {
+    scope = $rootScope.$new();
+  }));
+
+  it('should show alert messages', inject(function($compile) {
+    element = angular.element('<alert-messages></alert-messages>');
+    element = $compile(element)(scope);
+    scope.$digest();
+
+    expect(element.find('.alert-item').length).to.eql(2);
+  }));
+});

--- a/src/alertmessages/alertmessages.spec.js
+++ b/src/alertmessages/alertmessages.spec.js
@@ -2,31 +2,32 @@
 
 describe('Directive: alertMessages', function() {
 
-  // load the directive's module
-  beforeEach(module('polestar'));
-
   var element,
     scope;
 
-  beforeEach(module('polestar', function($provide) {
-    var mock = {
+  // load the directive's module
+  beforeEach(module('vlui', function($provide) {
+    // Mock the alerts service
+    $provide.value('Alerts', {
       alerts: [
-        {name: 'foo'},
-        {name: 'bar'}
+        {msg: 'foo'},
+        {msg: 'bar'}
       ]
-    };
-    $provide.value('Alerts', mock);
+    });
   }));
 
-  beforeEach(inject(function($rootScope) {
+  beforeEach(inject(function($rootScope, $compile) {
     scope = $rootScope.$new();
-  }));
-
-  it('should show alert messages', inject(function($compile) {
-    element = angular.element('<alert-messages></alert-messages>');
-    element = $compile(element)(scope);
+    var $el = angular.element('<alert-messages></alert-messages>');
+    element = $compile($el)(scope);
     scope.$digest();
-
-    expect(element.find('.alert-item').length).to.eql(2);
   }));
+
+  it('should show alert messages', function() {
+    expect(element.find('.alert-item').length).to.equal(2);
+    // Ignore the close buttons, which use an HTML entity for the close icon
+    element.find('a').remove();
+    expect(element.find('.alert-item').eq(0).text().trim()).to.equal('foo');
+    expect(element.find('.alert-item').eq(1).text().trim()).to.equal('bar');
+  });
 });

--- a/src/dataset/filedropzone.js
+++ b/src/dataset/filedropzone.js
@@ -15,24 +15,16 @@ angular.module('vlui')
 
     function isSizeValid(size, maxSize) {
       // Size is provided in bytes; maxSize is provided in megabytes
-      // Coerce maxSize to a number in case it comes in as a string
-      if (!maxSize || size / 1024 / 1024 < +maxSize) {
-        // max file size was not specified, is empty, or is sufficiently large
-        return true;
-      }
-
-      Alerts.add('File must be smaller than ' + maxSize + ' MB');
-      return false;
+      // Coerce maxSize to a number in case it comes in as a string,
+      // & return true when max file size was not specified, is empty,
+      // or is sufficiently large
+      return !maxSize || ( size / 1024 / 1024 < +maxSize );
     }
 
     function isTypeValid(type, validMimeTypes) {
-      if (!validMimeTypes || validMimeTypes.indexOf(type) > -1) {
         // If no mime type restrictions were provided, or the provided file's
         // type is whitelisted, type is valid
-        return true;
-      }
-      Alerts.add('Invalid file type. File must be one of following types: ' + validMimeTypes);
-      return false;
+      return !validMimeTypes || ( validMimeTypes.indexOf(type) > -1 );
     }
 
     return {
@@ -60,9 +52,15 @@ angular.module('vlui')
 
         function readFile(file) {
           if (!isTypeValid(file.type, scope.validMimeTypes)) {
+            scope.$apply(function() {
+              Alerts.add('Invalid file type. File must be one of following types: ' + scope.validMimeTypes);
+            });
             return;
           }
           if (!isSizeValid(file.size, scope.maxFileSize)) {
+            scope.$apply(function() {
+              Alerts.add('File must be smaller than ' + scope.maxFileSize + ' MB');
+            });
             return;
           }
           var reader = new FileReader();

--- a/src/dataset/pastedataset.js
+++ b/src/dataset/pastedataset.js
@@ -7,7 +7,7 @@
  * # pasteDataset
  */
 angular.module('vlui')
-  .directive('pasteDataset', function (Dataset, Alerts, Logger, Config, _, dl) {
+  .directive('pasteDataset', function (Dataset, Logger, Config, _, dl) {
     return {
       templateUrl: 'dataset/pastedataset.html',
       restrict: 'E',


### PR DESCRIPTION
This directive is used in the voyager source code, so it should be in VLUI so it can be used by both applications.

Moving this over also lets us solve #102 in all contexts:

The problem was again that the Alerts service was being called outside of Angular's scope digest cycle, so the change (displaying the alert) did not take effect until another digest was triggered when the modal was closed. `$apply`ing the change makes the alerts display as expected.

![102](https://cloud.githubusercontent.com/assets/442115/10525358/4cfaf214-7352-11e5-8766-c211e01c2a86.gif)

Closes #102
