### PR TITLE
Remove max file size limitation on dataset file upload directive

### DIFF
--- a/src/dataset/pastedataset.html
+++ b/src/dataset/pastedataset.html
@@ -2,7 +2,6 @@
 
 <file-dropzone
   dataset="dataset"
-  max-file-size="3"
   valid-mime-types="[text/csv, text/json, text/tsv]">
 
   <div class="upload-data">

--- a/src/dataset/pastedataset.html
+++ b/src/dataset/pastedataset.html
@@ -2,6 +2,7 @@
 
 <file-dropzone
   dataset="dataset"
+  max-file-size="10"
   valid-mime-types="[text/csv, text/json, text/tsv]">
 
   <div class="upload-data">


### PR DESCRIPTION
While Voyager & Polestar will certainly not perform at peak with data of extreme size, a hard limit is not useful: it should be up to the user's judgement whether the tool is performing adequately for their use, and capping the file upload size simply prevents them from using Voyager or Polestar on some datasets that, while slow, certainly "work".

See https://dl.dropboxusercontent.com/u/12770094/astronomy.csv , which partially breaks the UI and triggers an upload size warning but has been reported by @domoritz to work once loaded via URL
