### PR TITLE
Switch myria dataset selector to an ordinary dropdown

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -36,8 +36,6 @@
     "vega": "^1.5.0",
     "vega-lite": "^0.7.9",
     "datalib": "^1.3.0",
-    "angular-ui-select": "~0.11.2",
-    "selectize": "~0.12.1",
     "angular-google-analytics": "~1.1.1"
   },
   "resolutions": {

--- a/src/dataset/addmyriadataset.html
+++ b/src/dataset/addmyriadataset.html
@@ -3,14 +3,15 @@
     Select a dataset from the Myria instance at <code>{{myriaRestUrl}}</code>.
   </p>
   <form ng-submit="addDataset(myriaDataset)">
-		<ui-select ng-model="$parent.myriaDataset" style="width: 300px" theme="selectize" ng-disabled="disabled" reset-search-input="false">
-	    <ui-select-match placeholder="Select dataset...">{{$select.selected.relationName}}</ui-select-match>
-	    <ui-select-choices id="dataset-name" repeat="dataset in myriaDatasets"
-	       refresh="loadDatasets($select.search)"
-	       refresh-delay="100">
-	       {{ dataset.userName}}:{{dataset.programName}}:{{dataset.relationName }}
-			</ui-select-choices>
-	  </ui-select>
+    <div>
+      <select name="myria-dataset"
+        id="select-myria-dataset"
+        ng-disabled="disabled"
+        ng-model="myriaDataset"
+        ng-options="optionName(dataset) for dataset in myriaDatasets track by dataset.relationName">
+        <option value="">Select Dataset...</option>
+      </select>
+    </div>
     <button type="submit">Add dataset</button>
   </form>
 </div>

--- a/src/dataset/addmyriadataset.js
+++ b/src/dataset/addmyriadataset.js
@@ -35,6 +35,13 @@ angular.module('vlui')
             });
         };
 
+        // Load the available datasets from Myria
+        scope.loadDatasets('');
+
+        scope.optionName = function(dataset) {
+          return dataset.userName + ':' + dataset.programName + ':' + dataset.relationName;
+        };
+
         scope.addDataset = function(myriaDataset) {
           var dataset = {
             group: 'myria',


### PR DESCRIPTION
Fixes #101

After consulting with colleagues, we have no good solution for forcing a custom-rendered select UI (as is generated by ui-select) to overflow the edges of a div with `overflow: scroll` or `hidden` selected. As such, the only viable solutions to this problem would be to convert it to a list in the DOM, as is done on the change data tab; or to revert to a browser-default select box.

In the interest of time, I opted for the latter.

This should be reviewed, I'm particularly uncertain about what was happening with the `$select.search` value previously; but as is demonstrated in the gif below, this does permit the user to switch Myria datasets without the list being cut off.

![select](https://cloud.githubusercontent.com/assets/442115/10554114/8a96e2ea-742e-11e5-9f29-d0ba3743d662.gif)
