### PR TITLE
Implement `toggleSort` entirely in `vlplotgroup.js`.  

### DIFF
--- a/src/vlplotgroup/vlplotgroup.html
+++ b/src/vlplotgroup/vlplotgroup.html
@@ -46,7 +46,7 @@
       </a>
 
       <a ng-if="showSort && chart.vlSpec && toggleSort.support(chart.vlSpec, Dataset.stats)"
-        class="command" ng-click="toggleSort(chart.vlSpec)"
+        class="command" ng-click="toggleSort.toggle(chart.vlSpec)"
         >
         <i class="fa sort"
           ng-class="toggleSortClass(chart.vlSpec)"


### PR DESCRIPTION
Implement `toggleSort` entirely in `vlplotgroup.js`.   
- Now we can toggleSort in vega-lite 0.8 / vega 2.
- Now we have 5 modes in the toggler `['none', 'ordinal-ascending', 'ordinal-descending',
        'quantitative-ascending', 'quantitative-descending’]` with support for the future `custom` sort.  

(Companion with https://github.com/vega/vega-lite/pull/673)
