### PR TITLE
Avoid showing field-info if it's empty (in bookmark view)

### DIFF
--- a/src/components/vlplotgroup/vlplotgroup.html
+++ b/src/components/vlplotgroup/vlplotgroup.html
@@ -3,7 +3,7 @@
     class="vl-plot-group-header no-shrink">
     <div class="field-set-info" >
       <field-info ng-repeat="fieldDef in fieldSet"
-        ng-if="fieldSet"
+        ng-if="fieldDef.field"
         field-def='fieldDef'
         show-type='true'
         ng-class="{

--- a/src/components/vlplotgroup/vlplotgroup.html
+++ b/src/components/vlplotgroup/vlplotgroup.html
@@ -3,7 +3,7 @@
     class="vl-plot-group-header no-shrink">
     <div class="field-set-info" >
       <field-info ng-repeat="fieldDef in fieldSet"
-        ng-if="fieldDef.field"
+        ng-if="fieldSet && fieldDef.field"
         field-def='fieldDef'
         show-type='true'
         ng-class="{


### PR DESCRIPTION
This fixes the multiple empty `field-info` display in bookmark view
