### PR TITLE
Use vega-lite v1.0.16 because master needs vl.aggregate

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -36,7 +36,7 @@
     "heap": "~0.2.6",
     "jquery": "~2.2.0",
     "lodash": "~4.5.1",
-    "vega-lite": "~1.0.16",
+    "vega-lite": "1.0.16",
     "selectize": "~0.12.1"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -36,7 +36,7 @@
     "heap": "~0.2.6",
     "jquery": "~2.2.0",
     "lodash": "~4.5.1",
-    "vega-lite": "~1.0.12",
+    "vega-lite": "~1.0.16",
     "selectize": "~0.12.1"
   }
 }


### PR DESCRIPTION
Otherwise the data fields in PoleStar won't show up
