### PR TITLE
Make bookmark view organizable

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -29,6 +29,7 @@
     "angular-local-storage": "~0.2.3",
     "angular-mocks": "~1.5.7",
     "angular-sanitize": "~1.5.7",
+    "angular-sortable-view": "^0.0.15",
     "angular-touch": "~1.5.7",
     "angular-zeroclipboard": "~0.8.0",
     "compassql": "~0.1.0",

--- a/src/components/bookmarklist/bookmarklist.html
+++ b/src/components/bookmarklist/bookmarklist.html
@@ -6,8 +6,9 @@
   </div>
   <div class="flex-grow-1 scroll-y">
     <div ng-if="Bookmarks.length > 0"
-        class="hflex flex-wrap"
-        sv-root sv-part="Bookmarks.list" sv-on-sort="Bookmarks.reorder()">
+      class="hflex flex-wrap"
+      sv-root sv-part="Bookmarks.list" sv-on-sort="Bookmarks.reorder()">
+
       <vl-plot-group
         ng-repeat="bookmark in Bookmarks.list | orderObjectBy : 'timeAdded' : false"
         class="wrapped-vl-plot-group card"
@@ -29,6 +30,7 @@
 
         sv-element>
       </vl-plot-group>
+      <div sv-placeholder></div>
       <!-- FIXME: where does this field reference come from-->
     </div>
     <div class="vis-list-empty" ng-if="Bookmarks.length === 0">

--- a/src/components/bookmarklist/bookmarklist.html
+++ b/src/components/bookmarklist/bookmarklist.html
@@ -6,13 +6,14 @@
   </div>
   <div class="flex-grow-1 scroll-y">
     <div ng-if="Bookmarks.length > 0"
-        class="hflex flex-wrap">
+        class="hflex flex-wrap"
+        sv-root sv-part="Bookmarks.list" sv-on-sort="Bookmarks.reorder()">
       <vl-plot-group
-        ng-repeat="chart in Bookmarks.dict | orderObjectBy : 'timeAdded' : false"
+        ng-repeat="bookmark in Bookmarks.list | orderObjectBy : 'timeAdded' : false"
         class="wrapped-vl-plot-group card"
 
-        chart="chart"
-        field-set="chart.fieldSet"
+        chart="bookmark.chart"
+        field-set="bookmark.chart.fieldSet"
 
         show-bookmark="true"
         show-debug="consts.debug"
@@ -25,7 +26,9 @@
         tooltip="true"
 
         priority="consts.priority.bookmark"
-      ></vl-plot-group>
+
+        sv-element>
+      </vl-plot-group>
       <!-- FIXME: where does this field reference come from-->
     </div>
     <div class="vis-list-empty" ng-if="Bookmarks.length === 0">

--- a/src/components/bookmarklist/bookmarklist.html
+++ b/src/components/bookmarklist/bookmarklist.html
@@ -1,11 +1,11 @@
 <modal id="bookmark-list" ng-if="Bookmarks.isSupported">
   <div class="modal-header card no-top-margin no-right-margin">
     <modal-close-button on-close="logBookmarksClosed()"></modal-close-button>
-    <h2 class="no-bottom-margin">Bookmarks ({{ Bookmarks.length }})</h2>
+    <h2 class="no-bottom-margin">Bookmarks ({{ Bookmarks.list.length }})</h2>
     <a ng-click="Bookmarks.clear()"><i class="fa fa-trash-o"></i> Clear all</a>
   </div>
   <div class="flex-grow-1 scroll-y">
-    <div ng-if="Bookmarks.length > 0"
+    <div ng-if="Bookmarks.list.length > 0"
       class="hflex flex-wrap"
       sv-root sv-part="Bookmarks.list" sv-on-sort="Bookmarks.reorder()">
 
@@ -33,7 +33,7 @@
       <div sv-placeholder></div>
       <!-- FIXME: where does this field reference come from-->
     </div>
-    <div class="vis-list-empty" ng-if="Bookmarks.length === 0">
+    <div class="vis-list-empty" ng-if="Bookmarks.list.length === 0">
       You have no bookmarks
     </div>
   </div>

--- a/src/components/bookmarklist/bookmarklist.scss
+++ b/src/components/bookmarklist/bookmarklist.scss
@@ -1,0 +1,10 @@
+#bookmark-list .sv-placeholder {
+  border: 4px dashed white;
+  min-width: 200px;
+  min-height: 200px;
+  margin: 10px;
+}
+
+#bookmark-list .wrapped-vl-plot-group {
+  cursor:move;
+}

--- a/src/components/bookmarklist/bookmarklist.scss
+++ b/src/components/bookmarklist/bookmarklist.scss
@@ -1,6 +1,8 @@
 #bookmark-list .sv-placeholder {
-  border: 4px dashed white;
+  border: 4px dashed #ccd3de;
+  border-radius: 4px;
   min-width: 200px;
+
   min-height: 200px;
   margin: 10px;
 }

--- a/src/components/vlplotgroup/vlplotgroup.html
+++ b/src/components/vlplotgroup/vlplotgroup.html
@@ -65,19 +65,30 @@
         <i class="fa fa-refresh transpose"></i>
         <small ng-if="showLabel">Swap X/Y</small>
       </a>
+      
       <a ng-if="showBookmark && Bookmarks.isSupported"
         class="command"
-        ng-click="Bookmarks.toggle(chart)"
+        ng-click="toggleBookmark(chart)"
         ng-class="{disabled: !chart.vlSpec.encoding, active: Bookmarks.isBookmarked(chart.shorthand)}">
         <i class="fa fa-bookmark"></i>
         <small ng-if="showLabel">Bookmark</small>
       </a>
       <a ng-if="showExpand"
         ng-click="expandAction()"
-        class="command"
-        >
+        class="command">
         <i class="fa fa-expand"></i>
       </a>
+      <div ng-if="showBookmarkAlert"
+        class="bookmark-alert">
+        <div>Remove bookmark?</div>
+        <small>Your notes will be lost.</small>
+        <div>
+          <a ng-click="removeBookmark(chart)">
+            <i class="fa fa-trash-o"></i> remove it
+          </a>
+          <a ng-click="keepBookmark()"><i class="fa fa-bookmark"></i> keep it </a>
+        </div>
+      </div>
     </div>
   </div>
 

--- a/src/components/vlplotgroup/vlplotgroup.html
+++ b/src/components/vlplotgroup/vlplotgroup.html
@@ -115,5 +115,4 @@
     ng-change="Bookmarks.saveAnnotations(chart.shorthand)"
     placeholder = "notes"
   ></textarea>
-
 </div>

--- a/src/components/vlplotgroup/vlplotgroup.html
+++ b/src/components/vlplotgroup/vlplotgroup.html
@@ -111,7 +111,7 @@
 
   <textarea class="annotation"
     ng-if="Bookmarks.isBookmarked(chart.shorthand)"  
-    ng-model="Bookmarks.annotations[chart.shorthand]"
+    ng-model="Bookmarks.dict[chart.shorthand].annotation"
     ng-change="Bookmarks.saveAnnotations(chart.shorthand)"
     placeholder = "notes"
   ></textarea>

--- a/src/components/vlplotgroup/vlplotgroup.html
+++ b/src/components/vlplotgroup/vlplotgroup.html
@@ -98,4 +98,11 @@
     tooltip="tooltip"
   ></vl-plot>
 
+  <textarea class="annotation"
+    ng-if="Bookmarks.isBookmarked(chart.shorthand)"  
+    ng-model="Bookmarks.annotations[chart.shorthand]"
+    ng-change="Bookmarks.saveAnnotations(chart.shorthand)"
+    placeholder = "notes"
+  ></textarea>
+
 </div>

--- a/src/components/vlplotgroup/vlplotgroup.js
+++ b/src/components/vlplotgroup/vlplotgroup.js
@@ -60,6 +60,24 @@ angular.module('vlui')
         scope.consts = consts;
         scope.Dataset = Dataset;
 
+        // bookmark alert
+        scope.showBookmarkAlert = false;
+        scope.toggleBookmark = function(chart) {
+          if (Bookmarks.isBookmarked(chart.shorthand)) {
+            scope.showBookmarkAlert = !scope.showBookmarkAlert; // toggle alert
+          }
+          else {
+            Bookmarks.add(chart);
+          }
+        }
+        scope.removeBookmark = function(chart) {
+          Bookmarks.remove(chart);
+          scope.showBookmarkAlert = false;
+        }
+        scope.keepBookmark = function() {
+          scope.showBookmarkAlert = false;
+        }
+
         // Defer rendering the debug Drop popup until it is requested
         scope.renderPopup = false;
         // Use _.once because the popup only needs to be initialized once

--- a/src/components/vlplotgroup/vlplotgroup.scss
+++ b/src/components/vlplotgroup/vlplotgroup.scss
@@ -75,8 +75,10 @@
   margin-bottom: 5px;
   display: flex;
   .toolbox {
+    position: relative;
     flex-grow: 0;
     flex-shrink: 0;
+    text-align: right;
   }
   .toolbox .command {
     text-transform: uppercase;
@@ -117,4 +119,27 @@
   min-height: 60px;
   resize: none;
   border-color: lightgray;
+}
+
+.bookmark-alert {
+  position: absolute;
+  right: 0;
+  top: 20px;
+  color: white;
+  background-color: #38425D;
+  padding: 8px;
+  border-radius: 3px;
+  text-align: left;
+  z-index: 1;
+  min-width: 150px;
+}
+.bookmark-alert a {
+  color: white;
+  margin-right: 8px;
+}
+.bookmark-alert a:hover {
+  color: lightgray;
+}
+.bookmark-alert a i {
+  margin-right: 4px;
 }

--- a/src/components/vlplotgroup/vlplotgroup.scss
+++ b/src/components/vlplotgroup/vlplotgroup.scss
@@ -12,7 +12,7 @@
 // TODO consider if this can just be moved to .vis-list
 .vl-plot-group.wrapped-vl-plot-group {
   max-width: 520px;
-  max-height: 410px;
+  max-height: 390px;
   flex-grow: 1;
   padding-right: 11px;
   padding-bottom: 11px;
@@ -25,7 +25,7 @@
 .vl-plot-group.row-vl-plot-group {
   max-width: 100%;
 
-  max-height: 410px;
+  max-height: 390px;
 
   &.selected {
     border: 3px solid #aaa;

--- a/src/components/vlplotgroup/vlplotgroup.scss
+++ b/src/components/vlplotgroup/vlplotgroup.scss
@@ -12,7 +12,7 @@
 // TODO consider if this can just be moved to .vis-list
 .vl-plot-group.wrapped-vl-plot-group {
   max-width: 520px;
-  max-height: 310px;
+  max-height: 410px;
   flex-grow: 1;
   padding-right: 11px;
   padding-bottom: 11px;
@@ -25,7 +25,7 @@
 .vl-plot-group.row-vl-plot-group {
   max-width: 100%;
 
-  max-height: 310px;
+  max-height: 410px;
 
   &.selected {
     border: 3px solid #aaa;
@@ -111,4 +111,10 @@
 
 .dev-tool {
   width: 150px;
+}
+
+.vl-plot-group .annotation {
+  min-height: 60px;
+  resize: none;
+  border-color: lightgray;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,8 @@
 
 angular.module('vlui', [
     'LocalStorageModule',
-    'angular-google-analytics'
+    'angular-google-analytics',
+    'angular-sortable-view'
   ])
   .constant('_', window._)
   // datalib, vegalite, vega

--- a/src/index.scss
+++ b/src/index.scss
@@ -15,6 +15,7 @@ body{
   height:100%;
   overflow: hidden;
   margin: 0;
+  padding: 0;
   background-color: #E2E9F3;
   font-size: 12px;
   line-height: 18px;

--- a/src/services/bookmarks/bookmarks.service.js
+++ b/src/services/bookmarks/bookmarks.service.js
@@ -52,17 +52,6 @@ angular.module('vlui')
       Logger.logInteraction(Logger.actions.BOOKMARK_CLEAR);
     };
 
-    proto.toggle = function(chart) {
-
-      var shorthand = chart.shorthand;
-
-      if (this.isBookmarked(shorthand)) {
-        this.remove(chart);
-      } else {
-        this.add(chart);
-      }
-    };
-
     proto.add = function(chart) {
       var shorthand = chart.shorthand;
 

--- a/src/services/bookmarks/bookmarks.service.js
+++ b/src/services/bookmarks/bookmarks.service.js
@@ -11,6 +11,7 @@ angular.module('vlui')
   .service('Bookmarks', function(_, vl, localStorageService, Logger, Dataset) {
     var Bookmarks = function() {
       this.list = [];
+      this.annotations = {};
       this.length = 0;
       this.isSupported = localStorageService.isSupported;
     };
@@ -25,14 +26,27 @@ angular.module('vlui')
       localStorageService.set('bookmarkList', this.list);
     };
 
+    proto.saveAnnotations = function(shorthand) {
+      _.find(this.list, function(bookmark) { return bookmark.shorthand === shorthand; })
+        .chart.annotation = this.annotations[shorthand];
+      this.save();
+    }
+
     proto.load = function() {
       this.list = localStorageService.get('bookmarkList') || [];
       this.updateLength();
+
+      // load annotations
+      var annotations = this.annotations;
+      _.forEach(this.list, function(bookmark) {
+        annotations[bookmark.shorthand] = bookmark.chart.annotation;
+      });
     };
 
     proto.clear = function() {
       this.list.splice(0, this.list.length);
       this.updateLength();
+      this.annotations = {};
       this.save();
 
       Logger.logInteraction(Logger.actions.BOOKMARK_CLEAR);
@@ -58,6 +72,8 @@ angular.module('vlui')
 
       chart.stats = Dataset.stats;
 
+      chart.annotation = this.annotations[chart.shorthand];
+
       this.list.push({shorthand: shorthand, chart: _.cloneDeep(chart)});
 
       this.updateLength();
@@ -71,11 +87,16 @@ angular.module('vlui')
 
       console.log('removing', chart.vlSpec, shorthand);
 
+      // remove bookmark from this.list
       var index = this.list.findIndex(function(bookmark) { return bookmark.shorthand === shorthand; });
       if (index >= 0) {
         this.list.splice(index, 1);
       }
       this.updateLength();
+
+      // remove annotation
+      delete this.annotations[chart.shorthand];
+
       this.save();
 
       Logger.logInteraction(Logger.actions.BOOKMARK_REMOVE, shorthand);

--- a/src/services/bookmarks/bookmarks.service.js
+++ b/src/services/bookmarks/bookmarks.service.js
@@ -12,15 +12,10 @@ angular.module('vlui')
     var Bookmarks = function() {
       this.list = [];
       this.dict = {};
-      this.length = 0;
       this.isSupported = localStorageService.isSupported;
     };
 
     var proto = Bookmarks.prototype;
-
-    proto.updateLength = function() {
-      this.length = this.list.length;
-    };
 
     proto.save = function() {
       localStorageService.set('bookmarkList', this.list);
@@ -34,7 +29,6 @@ angular.module('vlui')
 
     proto.load = function() {
       this.list = localStorageService.get('bookmarkList') || [];
-      this.updateLength();
 
       // populate this.dict
       var dictionary = this.dict;
@@ -45,7 +39,6 @@ angular.module('vlui')
 
     proto.clear = function() {
       this.list.splice(0, this.list.length);
-      this.updateLength();
       this.dict = {};
       this.save();
 
@@ -65,7 +58,6 @@ angular.module('vlui')
 
       this.list.push({shorthand: shorthand, chart: _.cloneDeep(chart)});
 
-      this.updateLength();
       this.save();
 
       Logger.logInteraction(Logger.actions.BOOKMARK_ADD, shorthand);
@@ -81,7 +73,6 @@ angular.module('vlui')
       if (index >= 0) {
         this.list.splice(index, 1);
       }
-      this.updateLength();
 
       // remove bookmark from this.dict
       delete this.dict[chart.shorthand];


### PR DESCRIPTION
- [x] Allow user to re-order bookmarks using drag-and-drop
  - [x] Change `Bookmarks.dict` from `Object` to `Array`
  - [x] Clear any deprecated bookmarks from local storage. This is mostly beneficial for developers working on this project right now, who may have `Bookmarks.dict` as `Object` in their browser's local storage.
  - [x] Save the re-ordered bookmarks to local storage

![polestar](https://cloud.githubusercontent.com/assets/822034/16701857/77776c4c-4517-11e6-95ba-581df5e1d858.gif)

![voyager](https://cloud.githubusercontent.com/assets/822034/16701862/80392686-4517-11e6-9322-a17afdc683b8.gif)
- [x] When a vis is bookmarked, allow simple `textarea` annotation

![screen shot 2016-07-11 at 12 09 26 pm](https://cloud.githubusercontent.com/assets/822034/16743323/95449808-4760-11e6-83e6-1099fd11e28f.png)
- [x] Bookmark alert window
  ![bookmark alert](https://cloud.githubusercontent.com/assets/822034/16763111/40ebef6e-47dc-11e6-93be-e137bc0bad86.gif)
- [x] Tested with:
  - [x] PoleStar
  - [x] Voyager
