### PR TITLE
Annotate bookmarked vis

### DIFF
--- a/src/components/vlplotgroup/vlplotgroup.html
+++ b/src/components/vlplotgroup/vlplotgroup.html
@@ -98,4 +98,11 @@
     tooltip="tooltip"
   ></vl-plot>
 
+  <textarea class="annotation"
+    ng-if="Bookmarks.isBookmarked(chart.shorthand)"  
+    ng-model="chart.annotation"
+    ng-init="loadAnnotation(chart.shorthand)"
+    ng-change="saveAnnotation()"
+  >{{chart.annotation}}</textarea>
+
 </div>

--- a/src/components/vlplotgroup/vlplotgroup.html
+++ b/src/components/vlplotgroup/vlplotgroup.html
@@ -100,9 +100,9 @@
 
   <textarea class="annotation"
     ng-if="Bookmarks.isBookmarked(chart.shorthand)"  
-    ng-model="chart.annotation"
-    ng-init="loadAnnotation(chart.shorthand)"
-    ng-change="saveAnnotation()"
-  >{{chart.annotation}}</textarea>
+    ng-model="Bookmarks.annotations[chart.shorthand]"
+    ng-change="Bookmarks.saveAnnotations(chart.shorthand)"
+    placeholder = "notes"
+  ></textarea>
 
 </div>

--- a/src/components/vlplotgroup/vlplotgroup.js
+++ b/src/components/vlplotgroup/vlplotgroup.js
@@ -260,14 +260,6 @@ angular.module('vlui')
         scope.$on('$destroy', function() {
           scope.chart = null;
         });
-
-        scope.saveAnnotation = function() {
-          Bookmarks.save();
-        }
-
-        scope.loadAnnotation = function(chartShorthand) {
-          scope.chart.annotation = Bookmarks.getAnnotation(chartShorthand) || 'notes';
-        }
       }
     };
   });

--- a/src/components/vlplotgroup/vlplotgroup.js
+++ b/src/components/vlplotgroup/vlplotgroup.js
@@ -260,6 +260,14 @@ angular.module('vlui')
         scope.$on('$destroy', function() {
           scope.chart = null;
         });
+
+        scope.saveAnnotation = function() {
+          Bookmarks.save();
+        }
+
+        scope.loadAnnotation = function(chartShorthand) {
+          scope.chart.annotation = Bookmarks.getAnnotation(chartShorthand) || 'notes';
+        }
       }
     };
   });

--- a/src/components/vlplotgroup/vlplotgroup.scss
+++ b/src/components/vlplotgroup/vlplotgroup.scss
@@ -12,7 +12,7 @@
 // TODO consider if this can just be moved to .vis-list
 .vl-plot-group.wrapped-vl-plot-group {
   max-width: 520px;
-  max-height: 310px;
+  max-height: 410px;
   flex-grow: 1;
   padding-right: 11px;
   padding-bottom: 11px;
@@ -25,7 +25,7 @@
 .vl-plot-group.row-vl-plot-group {
   max-width: 100%;
 
-  max-height: 310px;
+  max-height: 410px;
 
   &.selected {
     border: 3px solid #aaa;
@@ -111,4 +111,10 @@
 
 .dev-tool {
   width: 150px;
+}
+
+.vl-plot-group .annotation {
+  min-height: 60px;
+  resize: none;
+  border-color: lightgray;
 }

--- a/src/services/bookmarks/bookmarks.service.js
+++ b/src/services/bookmarks/bookmarks.service.js
@@ -85,6 +85,11 @@ angular.module('vlui')
       this.save();
     }
 
+    proto.getAnnotation = function(shorthand) {
+      var savedBookmark = _.find(this.list, function(bookmark) { return bookmark.shorthand === shorthand; });
+      return savedBookmark ? savedBookmark.chart.annotation : undefined;
+    }
+
     proto.isBookmarked = function(shorthand) {
       return _.some(this.list, function(bookmark) { return bookmark.shorthand === shorthand; });
     };


### PR DESCRIPTION
Please merge #194 first.
- [x] When a vis is bookmarked, allow simple `textarea` annotation
- [x] Tested with PoleStar and Voyager

![screen shot 2016-07-11 at 12 09 26 pm](https://cloud.githubusercontent.com/assets/822034/16743323/95449808-4760-11e6-83e6-1099fd11e28f.png)

![screen shot 2016-07-11 at 12 12 59 pm](https://cloud.githubusercontent.com/assets/822034/16743374/ddc2f976-4760-11e6-9df7-da2097742a22.png)
