### PR TITLE
Export vlSpec and annotations

### DIFF
--- a/src/components/vlplotgroup/vlplotgroup.html
+++ b/src/components/vlplotgroup/vlplotgroup.html
@@ -72,6 +72,12 @@
         <i class="fa fa-bookmark"></i>
         <small ng-if="showLabel">Bookmark</small>
       </a>
+      <a
+        class="command"
+        ng-click="export()">
+        <i class="fa fa-code"></i>
+        <small ng-if="showLabel">Export Spec</small>
+      </a>
       <a ng-if="showExpand"
         ng-click="expandAction()"
         class="command"

--- a/src/components/vlplotgroup/vlplotgroup.js
+++ b/src/components/vlplotgroup/vlplotgroup.js
@@ -60,6 +60,15 @@ angular.module('vlui')
         scope.consts = consts;
         scope.Dataset = Dataset;
 
+        // export VL spec and annotation
+        scope.export = function() {
+          scope.chart.vlSpec.description = Bookmarks.annotations[scope.chart.shorthand];
+          var specWindow = window.open();
+          specWindow.document.open();
+          specWindow.document.write('<html><body><pre>' + JSON.stringify(scope.chart.vlSpec, null, 2) + '</pre></body></html>');  
+          specWindow.document.close();
+        }
+
         // Defer rendering the debug Drop popup until it is requested
         scope.renderPopup = false;
         // Use _.once because the popup only needs to be initialized once


### PR DESCRIPTION
Please merge #194 #197 first.
- [x] Export `vlSpec` to a new tab
  - [x] Text annotation is in `vlSpec.description` field
- [x] Tested with Voyager and PoleStar

Right now I'm using the [fa-code](http://fontawesome.io/icon/code/) icon for "export vlSpec". This icon looks like html but the spec is actually json. I'd prefer an icon like `{ }` but font awesome doesn't have it... Let me know if you have other suggestions.

![export](https://cloud.githubusercontent.com/assets/822034/16747656/e41cfb82-4774-11e6-91e1-40653e30c975.gif)
