### PR TITLE
Export all bookmark views and annotations

### DIFF
--- a/src/components/bookmarklist/bookmarklist.html
+++ b/src/components/bookmarklist/bookmarklist.html
@@ -2,7 +2,8 @@
   <div class="modal-header card no-top-margin no-right-margin">
     <modal-close-button on-close="logBookmarksClosed()"></modal-close-button>
     <h2 class="no-bottom-margin">Bookmarks ({{ Bookmarks.list.length }})</h2>
-    <a ng-click="Bookmarks.clear()"><i class="fa fa-trash-o"></i> Clear all</a>
+    <a class="bookmark-list-util" ng-click="Bookmarks.clear()"><i class="fa fa-trash-o"></i> Clear all </a>
+    <a class="bookmark-list-util" ng-click="Bookmarks.export()"><i class="fa fa-clipboard"></i> Export </a>
   </div>
   <div class="flex-grow-1 scroll-y">
     <div ng-if="Bookmarks.list.length > 0"

--- a/src/components/bookmarklist/bookmarklist.scss
+++ b/src/components/bookmarklist/bookmarklist.scss
@@ -10,3 +10,8 @@
 #bookmark-list .wrapped-vl-plot-group {
   cursor:move;
 }
+
+#bookmark-list .bookmark-list-util {
+  display: inline-block;
+  margin-right: 8px;
+}

--- a/src/services/bookmarks/bookmarks.service.js
+++ b/src/services/bookmarks/bookmarks.service.js
@@ -27,6 +27,25 @@ angular.module('vlui')
       this.save();
     }
 
+    // export all bookmarks and annotations
+    proto.export = function() {
+      var dictionary = this.dict;
+
+      // prepare export data
+      var exportSpecs = [];
+      _.forEach(this.list, function(bookmark) {
+        var spec = bookmark.chart.vlSpec;
+        spec.description = dictionary[bookmark.shorthand].annotation;
+        exportSpecs.push(spec);
+      })
+      
+      // write export data in a new tab
+      var exportWindow = window.open();
+      exportWindow.document.open();
+      exportWindow.document.write('<html><body><pre>' + JSON.stringify(exportSpecs, null, 2) + '</pre></body></html>');
+      exportWindow.document.close();
+    }
+
     proto.load = function() {
       this.list = localStorageService.get('bookmarkList') || [];
 


### PR DESCRIPTION
Please merge #194 first. 

Branch diff from #194:
https://github.com/vega/vega-lite-ui/compare/zqu/order-bookmarks...zqu/export-all-bookmarks

Export all bookmarked views (their specs) and annotations to an array.

![all bookmarks](https://cloud.githubusercontent.com/assets/822034/16750642/0e1b66b8-4788-11e6-8a15-3f2812e764ca.gif)
