### PR TITLE
Make function list more compact

### DIFF
--- a/src/components/channelshelf/channelshelf.html
+++ b/src/components/channelshelf/channelshelf.html
@@ -80,7 +80,7 @@
       <function-select field-def="encoding[channelId]" channel-id="channelId"></function-select>
 
       <div class="mb5" ng-if="allowedTypes.length>1">
-        <h4>Types</h4>
+        <h4>Type</h4>
         <label class="type-label"
           ng-repeat="type in allowedTypes">
           <input type="radio" ng-value="type" ng-model="encoding[channelId].type">

--- a/src/components/channelshelf/channelshelf.scss
+++ b/src/components/channelshelf/channelshelf.scss
@@ -99,7 +99,7 @@ $text-color: #212121;
 }
 
 .shelf-functions {
-  max-width: 260px;
+  max-width: 280px;
 }
 
 .shelf-properties, .shelf-functions{

--- a/src/components/channelshelf/channelshelf.scss
+++ b/src/components/channelshelf/channelshelf.scss
@@ -99,7 +99,7 @@ $text-color: #212121;
 }
 
 .shelf-functions {
-  width: 160px;
+  max-width: 260px;
 }
 
 .shelf-properties, .shelf-functions{

--- a/src/components/functionselect/functionselect.html
+++ b/src/components/functionselect/functionselect.html
@@ -1,5 +1,5 @@
 <div class="mb5" ng-if="func.list.aboveFold.length > 1 || func.list.aboveFold[0] !== undefined">
-  <h4>Functions</h4>
+  <h4>Function</h4>
   <!-- Above the fold functions -->
   <label class="func-label field-func" 
     ng-repeat="f in func.list.aboveFold"

--- a/src/components/functionselect/functionselect.html
+++ b/src/components/functionselect/functionselect.html
@@ -9,6 +9,7 @@
 
   <label ng-show="showAllFunctions"
     class="func-label field-func belowFold" 
+    ng-class="{'single-column': func.isTemporal}"
     ng-repeat="f in func.list.belowFold">
     <input type="radio" ng-value="f" ng-model="func.selected" ng-change="selectChanged()">
       {{f}}

--- a/src/components/functionselect/functionselect.html
+++ b/src/components/functionselect/functionselect.html
@@ -1,20 +1,23 @@
 <div class="mb5" ng-if="func.list.aboveFold.length > 1 || func.list.aboveFold[0] !== undefined">
   <h4>Functions</h4>
-  <label class="func-label field-func aboveFold" 
+  <!-- Above the fold functions -->
+  <label class="func-label field-func" 
     ng-repeat="f in func.list.aboveFold"
     ng-class="{none: !f}">
     <input type="radio" ng-value="f" ng-model="func.selected" ng-change="selectChanged()">
       {{f || 'NONE'}}
   </label>
 
+  <!-- Below the fold functions -->
   <label ng-show="showAllFunctions"
-    class="func-label field-func belowFold" 
+    class="func-label field-func" 
     ng-class="{'single-column': func.isTemporal}"
     ng-repeat="f in func.list.belowFold">
     <input type="radio" ng-value="f" ng-model="func.selected" ng-change="selectChanged()">
       {{f}}
   </label>
 
+  <!-- more and less toggles -->
   <div ng-hide="func.isCount"
     class="expand-collapse">
     <a ng-click="showAllFunctions=!showAllFunctions"> 
@@ -22,5 +25,4 @@
       <span ng-show="showAllFunctions"> less <i class="fa fa-angle-up" aria-hidden="true"></i> </span>
     </a>
   </div>
-
 </div>

--- a/src/components/functionselect/functionselect.html
+++ b/src/components/functionselect/functionselect.html
@@ -1,22 +1,26 @@
 <div class="mb5" ng-if="func.list.aboveFold.length > 1 || func.list.aboveFold[0] !== undefined">
   <h4>Function</h4>
   <!-- Above the fold functions -->
-  <label class="func-label field-func" 
-    ng-repeat="f in func.list.aboveFold"
-    ng-class="{none: !f, 'single-column': (!f && func.isTemporal)}">
-    <input type="radio" ng-value="f" ng-model="func.selected" ng-change="selectChanged()">
-      {{f || 'NONE'}}
-  </label>
-
+  <div>
+    <label class="func-label field-func" 
+      ng-repeat="f in func.list.aboveFold"
+      ng-class="{none: !f}">
+      <input type="radio" ng-value="f" ng-model="func.selected" ng-change="selectChanged()">
+        {{f || 'NONE'}}
+    </label>
+  </div>
+  
   <!-- Below the fold functions -->
-  <label ng-show="showAllFunctions"
-    class="func-label field-func" 
-    ng-class="{'single-column': func.isTemporal}"
-    ng-repeat="f in func.list.belowFold">
-    <input type="radio" ng-value="f" ng-model="func.selected" ng-change="selectChanged()">
-      {{f}}
-  </label>
-
+  <div>
+    <label ng-show="showAllFunctions"
+      class="func-label field-func" 
+      ng-class="{'single-column': func.isTemporal}"
+      ng-repeat="f in func.list.belowFold">
+      <input type="radio" ng-value="f" ng-model="func.selected" ng-change="selectChanged()">
+        {{f}}
+    </label>
+  </div>
+  
   <!-- more and less toggles -->
   <div ng-hide="func.isCount"
     class="expand-collapse">

--- a/src/components/functionselect/functionselect.html
+++ b/src/components/functionselect/functionselect.html
@@ -1,7 +1,27 @@
-<div class="mb5" ng-if="func.list.length > 1 || func.list[0] !== undefined">
+<div class="mb5" ng-if="func.list.aboveFold.length > 1 || func.list.aboveFold[0] !== undefined">
   <h4>Functions</h4>
-  <label class="func-label field-func" ng-repeat="f in func.list">
+  <label class="func-label field-func" ng-repeat="f in func.list.aboveFold">
     <input type="radio" ng-value="f" ng-model="func.selected" ng-change="selectChanged()">
-    {{f || '-'}}
+    {{f || 'NONE'}}
   </label>
+
+  <div class="expand-collapse">
+    <a ng-click="showAllFunctions=!showAllFunctions" ng-init="showAllFunctions=false"> 
+      <span ng-show="!showAllFunctions"> more <i class="fa fa-angle-down" aria-hidden="true"></i> </span>
+    </a>
+  </div>
+
+  <label ng-show="showAllFunctions"
+    class="func-label field-func" 
+    ng-repeat="f in func.list.belowFold">
+    <input type="radio" ng-value="f" ng-model="func.selected" ng-change="selectChanged()">
+    {{f || 'NONE'}}
+  </label>
+
+  <div class="expand-collapse">
+    <a ng-click="showAllFunctions=!showAllFunctions"> 
+      <span ng-show="showAllFunctions"> less <i class="fa fa-angle-up" aria-hidden="true"></i> </span>
+    </a>
+  </div>
+
 </div>

--- a/src/components/functionselect/functionselect.html
+++ b/src/components/functionselect/functionselect.html
@@ -15,7 +15,8 @@
       {{f}}
   </label>
 
-  <div class="expand-collapse">
+  <div ng-hide="func.isCount"
+    class="expand-collapse">
     <a ng-click="showAllFunctions=!showAllFunctions"> 
       <span ng-show="!showAllFunctions"> more <i class="fa fa-angle-down" aria-hidden="true"></i> </span>
       <span ng-show="showAllFunctions"> less <i class="fa fa-angle-up" aria-hidden="true"></i> </span>

--- a/src/components/functionselect/functionselect.html
+++ b/src/components/functionselect/functionselect.html
@@ -1,25 +1,22 @@
 <div class="mb5" ng-if="func.list.aboveFold.length > 1 || func.list.aboveFold[0] !== undefined">
   <h4>Functions</h4>
-  <label class="func-label field-func" ng-repeat="f in func.list.aboveFold">
+  <label class="func-label field-func aboveFold" 
+    ng-repeat="f in func.list.aboveFold"
+    ng-class="{none: !f}">
     <input type="radio" ng-value="f" ng-model="func.selected" ng-change="selectChanged()">
-    {{f || 'NONE'}}
+      {{f || 'NONE'}}
   </label>
 
-  <div class="expand-collapse">
-    <a ng-click="showAllFunctions=!showAllFunctions" ng-init="showAllFunctions=false"> 
-      <span ng-show="!showAllFunctions"> more <i class="fa fa-angle-down" aria-hidden="true"></i> </span>
-    </a>
-  </div>
-
   <label ng-show="showAllFunctions"
-    class="func-label field-func" 
+    class="func-label field-func belowFold" 
     ng-repeat="f in func.list.belowFold">
     <input type="radio" ng-value="f" ng-model="func.selected" ng-change="selectChanged()">
-    {{f || 'NONE'}}
+      {{f}}
   </label>
 
   <div class="expand-collapse">
     <a ng-click="showAllFunctions=!showAllFunctions"> 
+      <span ng-show="!showAllFunctions"> more <i class="fa fa-angle-down" aria-hidden="true"></i> </span>
       <span ng-show="showAllFunctions"> less <i class="fa fa-angle-up" aria-hidden="true"></i> </span>
     </a>
   </div>

--- a/src/components/functionselect/functionselect.html
+++ b/src/components/functionselect/functionselect.html
@@ -3,7 +3,7 @@
   <!-- Above the fold functions -->
   <label class="func-label field-func" 
     ng-repeat="f in func.list.aboveFold"
-    ng-class="{none: !f}">
+    ng-class="{none: !f, 'single-column': (!f && func.isTemporal)}">
     <input type="radio" ng-value="f" ng-model="func.selected" ng-change="selectChanged()">
       {{f || 'NONE'}}
   </label>

--- a/src/components/functionselect/functionselect.html
+++ b/src/components/functionselect/functionselect.html
@@ -6,7 +6,7 @@
       ng-repeat="f in func.list.aboveFold"
       ng-class="{none: !f}">
       <input type="radio" ng-value="f" ng-model="func.selected" ng-change="selectChanged()">
-        {{f || 'NONE'}}
+      {{f || 'NONE'}}
     </label>
   </div>
   
@@ -17,7 +17,7 @@
       ng-class="{'single-column': func.isTemporal}"
       ng-repeat="f in func.list.belowFold">
       <input type="radio" ng-value="f" ng-model="func.selected" ng-change="selectChanged()">
-        {{f}}
+      {{f}}
     </label>
   </div>
   

--- a/src/components/functionselect/functionselect.js
+++ b/src/components/functionselect/functionselect.js
@@ -24,8 +24,8 @@ angular.module('vlui')
         var timeUnits = {
           aboveFold: [undefined, "year", "quarter", "month", "date", "day", "hours", "minutes", "seconds", "yearmonthdate"],
           belowFold: ["hoursminutes", "hoursminutesseconds", "milliseconds", 
-            "minutesseconds", "secondsmilliseconds", "yearmonth", "yearmonthday", "yearmonthdayhours", 
-            "yearmonthdayhoursminutes", "yearmonthdayhoursminutesseconds", "yearquarter"]
+            "minutesseconds", "secondsmilliseconds", "yearmonth", "yearmonthdatehours", 
+            "yearmonthdatehoursminutes", "yearmonthdatehoursminutesseconds", "yearquarter"]
         }
 
         // aggregations for Q

--- a/src/components/functionselect/functionselect.js
+++ b/src/components/functionselect/functionselect.js
@@ -142,7 +142,7 @@ angular.module('vlui')
             }
             else if (isQ) {
               scope.func.list.aboveFold = aggregates.aboveFold;
-              scope.func.list.aboveFold.splice(1, 0, 'bin');
+              scope.func.list.aboveFold.splice(1, 0, 'bin'); // support 'bin' for quantitative fields
               scope.func.list.belowFold = aggregates.belowFold;
             }
 

--- a/src/components/functionselect/functionselect.js
+++ b/src/components/functionselect/functionselect.js
@@ -49,17 +49,17 @@ angular.module('vlui')
         // aggregates for Q
         var aggregates = {
           aboveFold: [
-            undefined,
+            undefined, // bin is here
             'min', 'max',
             'average', 'median', 
-            'sum' // bin is here
+            'sum', 'stdev'
           ],
           belowFold: [
-            'missing', 'valid',
-            'distinct', 'modeskew',
+            'variance', 'variancep',
+            'stdevp', 'modeskew',
             'q1', 'q3',
-            'stdev', 'stdevp',
-            'variance', 'variancep'
+            'valid', 'missing', 
+            'distinct'
           ] // hide COUNT for Q in the UI because we dedicate it to a special "# Count" field
         };
         aggregates.all = aggregates.aboveFold.concat(aggregates.belowFold)
@@ -135,13 +135,16 @@ angular.module('vlui')
             scope.func.list.belowFold=[];
             scope.func.selected = COUNT;
           } else {
-            scope.func.list.aboveFold = [].concat( isT ? timeUnits.aboveFold : [] )
-              .concat( isQ ? aggregates.aboveFold : [] )
-              // TODO: check supported type based on primitive data?
-              .concat( isQ ? ['bin'] : []);
-
-            scope.func.list.belowFold = [].concat( isT ? timeUnits.belowFold : [])
-              .concat( isQ ? aggregates.belowFold : [] );
+            // TODO: check supported type based on primitive data?
+            if (isT) {
+              scope.func.list.aboveFold = timeUnits.aboveFold;
+              scope.func.list.belowFold = timeUnits.belowFold;
+            }
+            else if (isQ) {
+              scope.func.list.aboveFold = aggregates.aboveFold;
+              scope.func.list.aboveFold.splice(1, 0, 'bin');
+              scope.func.list.belowFold = aggregates.belowFold;
+            }
 
             var defaultVal = (isOrdinalShelf &&
               (isQ && BIN) || (isT && consts.defaultTimeFn)

--- a/src/components/functionselect/functionselect.js
+++ b/src/components/functionselect/functionselect.js
@@ -22,18 +22,44 @@ angular.module('vlui')
 
         // timeUnits for T
         var timeUnits = {
-          aboveFold: [undefined, "year", "quarter", "month", "date", "day", "hours", "minutes", "seconds", "yearmonthdate"],
-          belowFold: ["hoursminutes", "hoursminutesseconds", "milliseconds", 
-            "minutesseconds", "secondsmilliseconds", "yearmonth", "yearmonthdatehours", 
-            "yearmonthdatehoursminutes", "yearmonthdatehoursminutesseconds", "yearquarter"]
+          aboveFold: [
+            undefined,
+            'year', 'quarter',
+            'month', 'date',
+            'day', 'hours',
+            'minutes', 'seconds',
+            'yearmonthdate'
+          ],
+          belowFold: [
+            'hoursminutes',
+            'hoursminutesseconds',
+            'milliseconds',
+            'minutesseconds',
+            'secondsmilliseconds',
+            'yearmonth',
+            'yearmonthdatehours',
+            'yearmonthdatehoursminutes',
+            'yearmonthdatehoursminutesseconds',
+            'yearquarter'
+          ]
         }
 
         // aggregations for Q
         var aggregations = {
-          aboveFold: [undefined, "min", "max", "median", "mean", "sum"],
-          belowFold: ["average", "distinct",
-            "missing", "modeskew", "q1", "q3", "stdev", "stdevp", "valid", "values", "variance", "variancep"] // there is no "count" for Q
-        }
+          aboveFold: [
+            undefined,
+            'min', 'max',
+            'median', 'mean',
+            'sum' // bin is here
+          ],
+          belowFold: [
+            'missing', 'valid',
+            'distinct', 'modeskew',
+            'q1', 'q3',
+            'stdev', 'stdevp',
+            'variance', 'variancep'
+          ] // there is no 'count' for Q
+        };
 
         function getTimeUnits(type) {
           if (type === 'temporal') {

--- a/src/components/functionselect/functionselect.js
+++ b/src/components/functionselect/functionselect.js
@@ -17,7 +17,8 @@ angular.module('vlui')
           list: {
             aboveFold: [],
             belowFold: [] // could be empty
-          }
+          },
+          isTemporal: false // for making belowFold timeUnits single-column
         };
 
         // timeUnits for T
@@ -124,6 +125,9 @@ angular.module('vlui')
           var isOrdinalShelf = ['row','column','shape'].indexOf(scope.channelId) !== -1,
             isQ = type === vl.type.QUANTITATIVE,
             isT = type === vl.type.TEMPORAL;
+
+          // for making belowFold timeUnits single-column
+          scope.func.isTemporal = isT; 
 
           if(pill.field === '*' && pill.aggregate === COUNT){
             scope.func.list.aboveFold=[COUNT];

--- a/src/components/functionselect/functionselect.js
+++ b/src/components/functionselect/functionselect.js
@@ -22,17 +22,16 @@ angular.module('vlui')
 
         // timeUnits for T
         var timeUnits = {
-          aboveFold: ["year", "quarter", "month", "date", "day", "hours", "yearmonthdate"],
+          aboveFold: [undefined, "year", "quarter", "month", "date", "day", "hours", "minutes", "seconds", "yearmonthdate"],
           belowFold: ["hoursminutes", "hoursminutesseconds", "milliseconds", 
-          "minutes", "minutesseconds", "quartermonth", "seconds", "secondsmilliseconds", 
-          "yeardate", "yearday", "yearmonth", "yearmonthday", "yearmonthdayhours", 
-          "yearmonthdayhoursminutes", "yearmonthdayhoursminutesseconds", "yearquarter", "yearquartermonth"]
+            "minutesseconds", "secondsmilliseconds", "yearmonth", "yearmonthday", "yearmonthdayhours", 
+            "yearmonthdayhoursminutes", "yearmonthdayhoursminutesseconds", "yearquarter"]
         }
 
         // aggregations for Q
         var aggregations = {
-          aboveFold: ["min", "max", "median", "mean", "sum"],
-          belowFold: ["argmax", "argmin", "average", "distinct",
+          aboveFold: [undefined, "min", "max", "median", "mean", "sum"],
+          belowFold: ["average", "distinct",
             "missing", "modeskew", "q1", "q3", "stdev", "stdevp", "valid", "values", "variance", "variancep"] // there is no "count" for Q
         }
 
@@ -109,8 +108,7 @@ angular.module('vlui')
             scope.func.list.aboveFold=[COUNT];
             scope.func.selected = COUNT;
           } else {
-            scope.func.list.aboveFold = ( isOrdinalShelf && (isQ || isT) ? [] : [undefined])
-              .concat( isT ? timeUnits.aboveFold : [] )
+            scope.func.list.aboveFold = [].concat( isT ? timeUnits.aboveFold : [] )
               .concat( isQ ? aggregations.aboveFold : [] )
               // TODO: check supported type based on primitive data?
               .concat( isQ ? ['bin'] : []);

--- a/src/components/functionselect/functionselect.js
+++ b/src/components/functionselect/functionselect.js
@@ -24,23 +24,22 @@ angular.module('vlui')
         var timeUnits = {
           aboveFold: [
             undefined,
-            'year', 'quarter',
-            'month', 'date',
-            'day', 'hours',
-            'minutes', 'seconds',
-            'yearmonthdate'
+            'yearmonthdate', 'year', 
+            'quarter', 'month', 
+            'date','day', 
+            'hours', 'minutes', 
+            'seconds', 'milliseconds'
           ],
           belowFold: [
-            'hoursminutes',
-            'hoursminutesseconds',
-            'milliseconds',
-            'minutesseconds',
-            'secondsmilliseconds',
+            'yearquarter',
             'yearmonth',
             'yearmonthdatehours',
             'yearmonthdatehoursminutes',
             'yearmonthdatehoursminutesseconds',
-            'yearquarter'
+            'hoursminutes',
+            'hoursminutesseconds',
+            'minutesseconds', 
+            'secondsmilliseconds'
           ]
         }
 

--- a/src/components/functionselect/functionselect.js
+++ b/src/components/functionselect/functionselect.js
@@ -41,10 +41,11 @@ angular.module('vlui')
             'minutesseconds', 
             'secondsmilliseconds'
           ]
-        }
+        };
+        timeUnits.all = timeUnits.aboveFold.concat(timeUnits.belowFold);
 
-        // aggregations for Q
-        var aggregations = {
+        // aggregates for Q
+        var aggregates = {
           aboveFold: [
             undefined,
             'min', 'max',
@@ -59,18 +60,16 @@ angular.module('vlui')
             'variance', 'variancep'
           ] // there is no 'count' for Q
         };
+        aggregates.all = aggregates.aboveFold.concat(aggregates.belowFold);
 
         function getTimeUnits(type) {
           if (type === 'temporal') {
-            if (!timeUnits.all || timeUnits.all.length <= 0) {
-              timeUnits.all = timeUnits.aboveFold.concat(timeUnits.belowFold);
-            }
             return timeUnits.all;
           }
           return [];
         }
 
-        function getAggregations(type) {
+        function getAggregates(type) {
           if(!type) {
             return [COUNT];
           }
@@ -78,10 +77,7 @@ angular.module('vlui')
           // HACK
           // TODO: make this correct for temporal as well
           if (type === 'quantitative' ){
-            if (!aggregations.all || aggregations.all.length <= 0) {
-              aggregations.all = aggregations.aboveFold.concat(aggregations.belowFold);
-            }
-            return aggregations.all;
+            return aggregates.all;
           }
           return [];
         }
@@ -104,7 +100,7 @@ angular.module('vlui')
           // reset field def
           // HACK: we're temporarily storing the maxbins in the pill
           pill.bin = selectedFunc === BIN ? true : undefined;
-          pill.aggregate = getAggregations(type).indexOf(selectedFunc) !== -1 ? selectedFunc : undefined;
+          pill.aggregate = getAggregates(type).indexOf(selectedFunc) !== -1 ? selectedFunc : undefined;
           pill.timeUnit = getTimeUnits(type).indexOf(selectedFunc) !== -1 ? selectedFunc : undefined;
 
           if(!_.isEqual(oldPill, pill)){
@@ -134,12 +130,12 @@ angular.module('vlui')
             scope.func.selected = COUNT;
           } else {
             scope.func.list.aboveFold = [].concat( isT ? timeUnits.aboveFold : [] )
-              .concat( isQ ? aggregations.aboveFold : [] )
+              .concat( isQ ? aggregates.aboveFold : [] )
               // TODO: check supported type based on primitive data?
               .concat( isQ ? ['bin'] : []);
 
             scope.func.list.belowFold = [].concat( isT ? timeUnits.belowFold : [])
-              .concat( isQ ? aggregations.belowFold : [] );
+              .concat( isQ ? aggregates.belowFold : [] );
 
             var defaultVal = (isOrdinalShelf &&
               (isQ && BIN) || (isT && consts.defaultTimeFn)

--- a/src/components/functionselect/functionselect.js
+++ b/src/components/functionselect/functionselect.js
@@ -51,7 +51,7 @@ angular.module('vlui')
           aboveFold: [
             undefined,
             'min', 'max',
-            'median', 'mean',
+            'average', 'median', 
             'sum' // bin is here
           ],
           belowFold: [

--- a/src/components/functionselect/functionselect.js
+++ b/src/components/functionselect/functionselect.js
@@ -18,7 +18,8 @@ angular.module('vlui')
             aboveFold: [],
             belowFold: [] // could be empty
           },
-          isTemporal: false // for making belowFold timeUnits single-column
+          isTemporal: false, // for making belowFold timeUnits single-column
+          isCount: false // hide "more" & "less" toggle for COUNT
         };
 
         // timeUnits for T
@@ -129,8 +130,12 @@ angular.module('vlui')
           // for making belowFold timeUnits single-column
           scope.func.isTemporal = isT; 
 
+          // hide "more" & "less" toggles for COUNT
+          scope.func.isCount = pill.field === '*';
+
           if(pill.field === '*' && pill.aggregate === COUNT){
             scope.func.list.aboveFold=[COUNT];
+            scope.func.list.belowFold=[];
             scope.func.selected = COUNT;
           } else {
             scope.func.list.aboveFold = [].concat( isT ? timeUnits.aboveFold : [] )

--- a/src/components/functionselect/functionselect.js
+++ b/src/components/functionselect/functionselect.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('vlui')
-  .directive('functionSelect', function(_, consts, vl, Pills, Logger, Schema) {
+  .directive('functionSelect', function(_, consts, vl, Pills, Logger) {
     return {
       templateUrl: 'components/functionselect/functionselect.html',
       restrict: 'E',

--- a/src/components/functionselect/functionselect.js
+++ b/src/components/functionselect/functionselect.js
@@ -142,6 +142,7 @@ angular.module('vlui')
             }
             else if (isQ) {
               scope.func.list.aboveFold = aggregates.aboveFold;
+              // HACK
               scope.func.list.aboveFold.splice(1, 0, 'bin'); // support 'bin' for quantitative fields
               scope.func.list.belowFold = aggregates.belowFold;
             }

--- a/src/components/functionselect/functionselect.js
+++ b/src/components/functionselect/functionselect.js
@@ -60,9 +60,10 @@ angular.module('vlui')
             'q1', 'q3',
             'stdev', 'stdevp',
             'variance', 'variancep'
-          ] // there is no 'count' for Q
+          ] // hide COUNT for Q in the UI because we dedicate it to a special "# Count" field
         };
-        aggregates.all = aggregates.aboveFold.concat(aggregates.belowFold);
+        aggregates.all = aggregates.aboveFold.concat(aggregates.belowFold)
+          .concat([COUNT]); // COUNT is a valid aggregate
 
         function getTimeUnits(type) {
           if (type === 'temporal') {

--- a/src/components/functionselect/functionselect.js
+++ b/src/components/functionselect/functionselect.js
@@ -25,12 +25,12 @@ angular.module('vlui')
         // timeUnits for T
         var timeUnits = {
           aboveFold: [
-            undefined,
-            'yearmonthdate', 'year', 
+            undefined, 'year', 
             'quarter', 'month', 
             'date','day', 
             'hours', 'minutes', 
-            'seconds', 'milliseconds'
+            'seconds', 'milliseconds',
+            'yearmonthdate'
           ],
           belowFold: [
             'yearquarter',
@@ -52,14 +52,14 @@ angular.module('vlui')
             undefined, // bin is here
             'min', 'max',
             'average', 'median', 
-            'sum', 'stdev'
+            'sum'
           ],
           belowFold: [
-            'variance', 'variancep',
-            'stdevp', 'modeskew',
-            'q1', 'q3',
             'valid', 'missing', 
-            'distinct'
+            'distinct', 'modeskew',
+            'q1', 'q3',
+            'stdev', 'stdevp', 
+            'variance', 'variancep'
           ] // hide COUNT for Q in the UI because we dedicate it to a special "# Count" field
         };
         aggregates.all = aggregates.aboveFold.concat(aggregates.belowFold)

--- a/src/components/functionselect/functionselect.js
+++ b/src/components/functionselect/functionselect.js
@@ -73,10 +73,6 @@ angular.module('vlui')
         }
 
         function getAggregates(type) {
-          if(!type) {
-            return [COUNT];
-          }
-
           // HACK
           // TODO: make this correct for temporal as well
           if (type === 'quantitative' ){

--- a/src/components/functionselect/functionselect.scss
+++ b/src/components/functionselect/functionselect.scss
@@ -8,7 +8,6 @@ label.func-label.field-func.single-column {
 }
 
 label.func-label.field-func.none {
-  display: block;
   color: gray;
 }
 

--- a/src/components/functionselect/functionselect.scss
+++ b/src/components/functionselect/functionselect.scss
@@ -1,3 +1,21 @@
+label.func-label.field-func {
+  font-weight: normal;
+}
+
+label.func-label.field-func.aboveFold {
+  width: 120px;
+}
+
+label.func-label.field-func.belowFold {
+  display: block;
+}
+
+label.func-label.field-func.none {
+  display: block;
+  color: gray;
+}
+
 .expand-collapse {
   text-align: center;
+  margin-bottom: -5px;
 }

--- a/src/components/functionselect/functionselect.scss
+++ b/src/components/functionselect/functionselect.scss
@@ -1,0 +1,3 @@
+.expand-collapse {
+  text-align: center;
+}

--- a/src/components/functionselect/functionselect.scss
+++ b/src/components/functionselect/functionselect.scss
@@ -3,7 +3,7 @@ label.func-label.field-func {
 }
 
 label.func-label.field-func.aboveFold {
-  width: 120px;
+  width: 130px; // set width to roughly half of .shelf-functions to create double columns
 }
 
 label.func-label.field-func.belowFold {

--- a/src/components/functionselect/functionselect.scss
+++ b/src/components/functionselect/functionselect.scss
@@ -2,12 +2,12 @@ label.func-label.field-func {
   font-weight: normal;
 }
 
-label.func-label.field-func.aboveFold {
+label.func-label.field-func {
   width: 130px; // set width to roughly half of .shelf-functions to create double columns
 }
 
-label.func-label.field-func.belowFold {
-  display: block;
+label.func-label.field-func.single-column {
+  width: 260px; // set width slightly smaller than .shelf-functions to create single column
 }
 
 label.func-label.field-func.none {

--- a/src/components/functionselect/functionselect.scss
+++ b/src/components/functionselect/functionselect.scss
@@ -1,8 +1,5 @@
 label.func-label.field-func {
   font-weight: normal;
-}
-
-label.func-label.field-func {
   width: 130px; // set width to roughly half of .shelf-functions to create double columns
 }
 

--- a/src/components/functionselect/functionselect.test.js
+++ b/src/components/functionselect/functionselect.test.js
@@ -56,14 +56,14 @@ describe('Directive: functionSelect', function() {
     element = angular.element('<function-select field-def="encoding[channel]" channel="channel" pills="pills"></function-select>');
     element = $compile(element)(scope);
     scope.$digest();
-    expect(element.find('input').length).to.eql(21);
+    expect(element.find('input').length).to.eql(17);
   });
 
   it('should have correct number of radio', function() {
     element = angular.element('<function-select  field-def="encoding[channel3]" channel="channel3" pills="pills"></function-select>');
     element = $compile(element)(scope);
     scope.$digest();
-    expect(element.find('input').length).to.eql(25);
+    expect(element.find('input').length).to.eql(20);
   });
 
   it('should not show other options for count field', function() {


### PR DESCRIPTION
Fix #196

Show "above the fold" functions (aggregations, bins, timeUnits) in the `functionselect` panel. Functions below the fold will reveal if user clicks `more`.

The order of the above the fold functions is specified in #196. 

Used local aggregation and timeUnit list (instead of getting from schema) because aggregations and timeUnits are unlikely to change.

Count fields has only one function: `COUNT`

Passed `npm run lint`

Passed `npm run test`

![q](https://cloud.githubusercontent.com/assets/822034/16883861/242e07da-4a7b-11e6-90fd-f7035827954e.gif)

![t](https://cloud.githubusercontent.com/assets/822034/16883866/274ac912-4a7b-11e6-9477-5e38001b9188.gif)
