### PR TITLE
Redesign field info to support wildcard field / channel

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -32,7 +32,7 @@
     "angular-sortable-view": "^0.0.15",
     "angular-touch": "~1.5.7",
     "angular-zeroclipboard": "~0.8.0",
-    "compassql": "~0.3.0",
+    "compassql": "~0.3.1",
     "drop": "~1.4.2",
     "heap": "~0.2.6",
     "jquery": "~2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vega-lite-ui",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "repository": "http://github.com/vega/vega-lite-ui",
   "author": {
     "name": "UW Interactive Data Lab",

--- a/src/components/fieldinfo/fieldinfo.scss
+++ b/src/components/fieldinfo/fieldinfo.scss
@@ -123,6 +123,7 @@ $any-hover-color: #666;
   }
 }
 
+
 .field-info.unselected {
   border: 1px dashed hsla(0,0%,0%,0.15);
   background-color: #fafafa;
@@ -132,10 +133,10 @@ $any-hover-color: #666;
   border: 1px solid hsla(0,0%,0%,0.15);
   background-color: hsla(0,0%,93%,0.8);
   font-weight: 500;
+}
 
-  &.any {
-    background-color: #C5EAEB
-  }
+.field-info.any, .field-info.any.selected, .field-info.any.unselected, .field-info.any.pill {
+  background-color: #C5EAEB
 }
 
 .field-info.pill {

--- a/src/components/schemalist/schemalistitem.html
+++ b/src/components/schemalist/schemalistitem.html
@@ -2,6 +2,7 @@
   show-type="true"
   show-info="true"
   class="pill list-item draggable full-width no-right-margin"
+  ng-class="{any: isEnumSpec(fieldDef.field)}"
   ng-model="pill"
   data-drag="true"
   jqyoui-draggable="{placeholder: 'keep', deepCopy:  true, onStart: 'fieldDragStart', onStop:'fieldDragStop'}"

--- a/src/components/schemalist/schemalistitem.js
+++ b/src/components/schemalist/schemalistitem.js
@@ -7,7 +7,7 @@
  * # schemaListItem
  */
 angular.module('vlui')
-  .directive('schemaListItem', function (Pills) {
+  .directive('schemaListItem', function (Pills, cql) {
     return {
       templateUrl: 'components/schemalist/schemalistitem.html',
       restrict: 'E',
@@ -16,6 +16,8 @@ angular.module('vlui')
         fieldDef:'='
       },
       link: function postLink(scope) {
+        scope.isEnumSpec = cql.enumSpec.isEnumSpec;
+
         scope.fieldDragStart = function() {
           var fieldDef = scope.fieldDef;
 

--- a/src/components/vlplotgroup/vlplotgroup.html
+++ b/src/components/vlplotgroup/vlplotgroup.html
@@ -5,11 +5,13 @@
       <field-info ng-repeat="fieldDef in fieldSet"
         ng-if="fieldSet && fieldDef.field"
         field-def='fieldDef'
+        enum-spec-index="chart.enumSpecIndex"
         show-type='true'
         ng-class="{
           selected: alwaysSelected || (isSelected && isSelected(fieldDef.field)),
           unselected: isSelected && !isSelected(fieldDef.field),
-          highlighted: (highlighted||{})[fieldDef.field]
+          highlighted: (highlighted||{})[fieldDef.field],
+          any: isFieldAny(chart, $index)
         }"
         ng-mouseover="(highlighted||{})[fieldDef.field] = true"
         ng-mouseout="(highlighted||{})[fieldDef.field] = false"
@@ -65,7 +67,7 @@
         <i class="fa fa-refresh transpose"></i>
         <small ng-if="showLabel">Swap X/Y</small>
       </a>
-      
+
       <a ng-if="showBookmark && Bookmarks.isSupported"
         class="command"
         ng-click="toggleBookmark(chart)"
@@ -110,7 +112,7 @@
   ></vl-plot>
 
   <textarea class="annotation"
-    ng-if="Bookmarks.isBookmarked(chart.shorthand)"  
+    ng-if="Bookmarks.isBookmarked(chart.shorthand)"
     ng-model="Bookmarks.dict[chart.shorthand].annotation"
     ng-change="Bookmarks.saveAnnotations(chart.shorthand)"
     placeholder = "notes"

--- a/src/components/vlplotgroup/vlplotgroup.js
+++ b/src/components/vlplotgroup/vlplotgroup.js
@@ -70,6 +70,15 @@ angular.module('vlui')
           }
         };
 
+        scope.isFieldAny = function(chart, index) {
+          if (chart.enumSpecIndex) {
+            if (chart.enumSpecIndex.encodings && chart.enumSpecIndex.encodings[index] && chart.enumSpecIndex.encodings[index].field) {
+              return true;
+            }
+          }
+          return false;
+        };
+
         scope.removeBookmark = function(chart) {
           Bookmarks.remove(chart);
           scope.showBookmarkAlert = false;

--- a/src/components/vlplotgrouplist/vlplotgrouplist.js
+++ b/src/components/vlplotgrouplist/vlplotgrouplist.js
@@ -38,7 +38,8 @@ angular.module('vlui')
             cql.modelGroup.getTopItem(item) :
             item;
           return {
-            fieldSet: specM.getEncodings(),
+            enumSpecIndex: specM.enumSpecIndex,
+            fieldSet: specM.specQuery.encodings,
             vlSpec: specM.toSpec()
           };
         }


### PR DESCRIPTION
Part of https://github.com/uwdata/voyager2/issues/16 Redesign field info to support wildcard field
- Bump CQL to 0.3.1
- Use full set of encoding queries from spec model even if it's the one that is `autoCount=false` to retain correct set of index
- Update `<schema-index>` and `<vl-plot-group>` to use correct color for enumSpec
  - include `enumSpecIndex` in the `chart` object in `<vl-plot-group-list>`
