### PR TITLE
Support for "Sneak Peak Full Spec for a particular view in the shelf"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vega-lite-ui",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "repository": "http://github.com/vega/vega-lite-ui",
   "author": {
     "name": "UW Interactive Data Lab",

--- a/src/components/shelves/shelves.html
+++ b/src/components/shelves/shelves.html
@@ -1,4 +1,4 @@
-<div class="card abs-100">
+<div class="card shelves abs-100">
   <a class="right"  ng-click="clear()"><i class="fa fa-eraser"></i> Clear</a>
   <h2>Encoding</h2>
 

--- a/src/components/shelves/shelves.js
+++ b/src/components/shelves/shelves.js
@@ -8,6 +8,7 @@ angular.module('vlui')
       restrict: 'E',
       scope: {
         spec: '=',
+        preview: '=',
         supportAny: '='
       },
       replace: true,
@@ -42,7 +43,10 @@ angular.module('vlui')
               return anyChannelIds;
             }, []);
           }
-          Pills.update(spec);
+          // Only call Pills.update, which will trigger Spec.spec to update if it's not a preview.
+          if (!$scope.preview) {
+            Pills.update(spec);
+          }
         }, true); //, true /* watch equality rather than reference */);
       }
     };

--- a/src/components/shelves/shelves.scss
+++ b/src/components/shelves/shelves.scss
@@ -1,3 +1,7 @@
 .shelf-pane {
   margin-bottom: 20px;
 }
+
+.shelves.preview {
+  opacity: 0.8;
+}

--- a/src/components/vlplotgroup/vlplotgroup.html
+++ b/src/components/vlplotgroup/vlplotgroup.html
@@ -1,7 +1,8 @@
 <div class="vl-plot-group vflex">
   <div ng-show="showExpand || fieldSet || showTranspose || showBookmark && Bookmarks.isSupported || showToggle"
-    class="vl-plot-group-header no-shrink">
-    <div class="field-set-info" >
+      class="vl-plot-group-header no-shrink"
+    >
+    <div class="field-set-info">
       <field-info ng-repeat="fieldDef in fieldSet"
         ng-if="fieldSet && fieldDef.field"
         field-def='fieldDef'
@@ -13,8 +14,8 @@
           highlighted: (highlighted||{})[fieldDef.field],
           any: isFieldAny(chart, $index)
         }"
-        ng-mouseover="(highlighted||{})[fieldDef.field] = true"
-        ng-mouseout="(highlighted||{})[fieldDef.field] = false"
+        ng-mouseover="fieldInfoMouseover(fieldDef)"
+        ng-mouseout="fieldInfoMouseout(fieldDef)"
       ></field-info>
     </div>
     <div class="toolbox">

--- a/src/components/vlplotgroup/vlplotgroup.js
+++ b/src/components/vlplotgroup/vlplotgroup.js
@@ -7,7 +7,7 @@
  * # visListItem
  */
 angular.module('vlui')
-  .directive('vlPlotGroup', function (Bookmarks, consts, vg, vl, Dataset, Logger, _) {
+  .directive('vlPlotGroup', function (Bookmarks, consts, vg, vl, Dataset, Logger, _, Pills) {
     return {
       templateUrl: 'components/vlplotgroup/vlplotgroup.html',
       restrict: 'E',
@@ -27,6 +27,7 @@ angular.module('vlui')
 
         alwaysScrollable: '=',
         configSet: '@',
+        enablePillsPreview: '=',
         maxHeight: '=',
         maxWidth: '=',
         overflow: '=',
@@ -67,6 +68,22 @@ angular.module('vlui')
           }
           else {
             Bookmarks.add(chart);
+          }
+        };
+
+        scope.fieldInfoMouseover = function(fieldDef) {
+          (scope.highlighted||{})[fieldDef.field] = true;
+
+          if (scope.enablePillsPreview) {
+            Pills.preview(scope.chart.vlSpec);
+          }
+        };
+
+        scope.fieldInfoMouseout = function(fieldDef) {
+          (scope.highlighted||{})[fieldDef.field] = false;
+
+          if (scope.enablePillsPreview) {
+            Pills.preview(null);
           }
         };
 

--- a/src/components/vlplotgrouplist/vlplotgrouplist.html
+++ b/src/components/vlplotgrouplist/vlplotgrouplist.html
@@ -8,6 +8,7 @@
       chart="chart"
       is-in-list="isInList"
 
+      enable-pills-preview="enablePillsPreview"
       field-set="chart.fieldSet"
       show-bookmark="true"
       show-debug="consts.debug && consts.debugInList"

--- a/src/components/vlplotgrouplist/vlplotgrouplist.js
+++ b/src/components/vlplotgrouplist/vlplotgrouplist.js
@@ -8,7 +8,8 @@ angular.module('vlui')
       replace: true,
       scope: {
         /** An instance of specQueryModelGroup */
-        modelGroup: '='
+        modelGroup: '=',
+        enablePillsPreview: '='
       },
       link: function postLink(scope , element /*, attrs*/) {
         scope.consts = consts;

--- a/src/services/pills/pills.service.js
+++ b/src/services/pills/pills.service.js
@@ -15,6 +15,7 @@ angular.module('vlui')
       set: set,
       remove: remove,
       parse: parse,
+      preview: preview,
       update: update,
       reset: reset,
       dragDrop: dragDrop,
@@ -83,6 +84,17 @@ angular.module('vlui')
     function parse(spec) {
       if (Pills.listener) {
         Pills.listener.parse(spec);
+      }
+    }
+
+    /**
+     * Add Spec to be previewed (for Voyager2)
+     *
+     * @param {any} spec
+     */
+    function preview(spec) {
+      if (Pills.listener) {
+        Pills.listener.preview(spec);
       }
     }
 


### PR DESCRIPTION
(https://github.com/uwdata/voyager2/issues/20)
- Show Preview `<shelves>` with opacity = 0.8
- Make `<shelves>` do not send update to Pills if it's a preview shelf.
- `enablePillsPreview` flag for
- Make hovering and uncovering `<field-info>` in `<vl-plot-group>` triggers `Pills.preview`, which triggers the listener in VY2 to show preview shelf.

Follow Up TODO:
- Better Visual Design for Preview Shelf
