### PR TITLE
Polish Q Filter

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -38,6 +38,7 @@
     "jquery": "~2.2.0",
     "lodash": "~4.5.1",
     "vega-lite": "1.0.16",
-    "selectize": "~0.12.1"
+    "selectize": "~0.12.1",
+    "angular-rangeslider": "~0.0.14"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -37,7 +37,7 @@
     "heap": "~0.2.6",
     "jquery": "~2.2.0",
     "lodash": "~4.5.1",
-    "vega-lite": "1.0.16",
+    "vega-lite": "~1.1.1",
     "selectize": "~0.12.1",
     "angular-rangeslider": "~0.0.14"
   }

--- a/src/components/fieldinfo/fieldinfo.html
+++ b/src/components/fieldinfo/fieldinfo.html
@@ -35,6 +35,7 @@
       </a>
     </span>
 
+    <!-- Hide Filter for count field since we don't have post-aggregation filter yet--> 
     <span ng-if="fieldDef.aggregate!=='count'"
       class="no-shrink filter" ng-show="showFilter">
       <a class="filter-field" ng-click="filterAction()">

--- a/src/components/fieldinfo/fieldinfo.html
+++ b/src/components/fieldinfo/fieldinfo.html
@@ -35,7 +35,8 @@
       </a>
     </span>
 
-    <span class="no-shrink filter" ng-show="showFilter">
+    <span ng-if="fieldDef.aggregate!=='count'"
+      class="no-shrink filter" ng-show="showFilter">
       <a class="filter-field" ng-click="filterAction()">
         <i class="fa fa-filter"></i>
       </a>

--- a/src/components/filter/filtershelves.scss
+++ b/src/components/filter/filtershelves.scss
@@ -1,3 +1,6 @@
+@import "angular-rangeslider/scss/rangeSlider"; // requires Compass
+
+
 .shelf.filter-shelf {
   display: flex;
   flex-direction: column;

--- a/src/components/filter/filtershelves.scss
+++ b/src/components/filter/filtershelves.scss
@@ -1,6 +1,3 @@
-@import "angular-rangeslider/scss/rangeSlider"; // requires Compass
-
-
 .shelf.filter-shelf {
   display: flex;
   flex-direction: column;

--- a/src/components/filter/filtershelves.scss
+++ b/src/components/filter/filtershelves.scss
@@ -3,9 +3,17 @@
   flex-direction: column;
   height: auto;
   max-height: 150px;
+  background-color: white;
 
   .field-drop {
     flex-shrink: 0;
+    border: none;
+  }
+
+  .field-info.selected {
+    border: none;
+    border-bottom-left-radius: 0px;
+    border-bottom-right-radius: 0px;
   }
 }
 

--- a/src/components/filter/quantitativefilter.html
+++ b/src/components/filter/quantitativefilter.html
@@ -1,3 +1,10 @@
 <div>
-  {{field}} (Q)
+  <div>
+    <span class="right">{{domainMax}}</span>
+    <span>{{domainMin}}</span>
+  </div>
+  <div range-slider min="domainMin"" max="domainMax" model-min="filter.range[0]" model-max="filter.range[1]">
+  </div>
 </div>
+
+

--- a/src/components/filter/quantitativefilter.html
+++ b/src/components/filter/quantitativefilter.html
@@ -1,9 +1,11 @@
 <div>
   <div>
-    <span class="right">{{domainMax}}</span>
-    <span>{{domainMin}}</span>
+    <span class="right domain-label">{{domainMax}}</span>
+    <span class="domain-label">{{domainMin}}</span>
   </div>
-  <div range-slider min="domainMin"" max="domainMax" model-min="filter.range[0]" model-max="filter.range[1]">
+  <div range-slider min="domainMin"" max="domainMax" 
+    model-min="filter.range[0]" model-max="filter.range[1]"
+    show-values="true" attach-handle-values="true">
   </div>
 </div>
 

--- a/src/components/filter/quantitativefilter.js
+++ b/src/components/filter/quantitativefilter.js
@@ -7,16 +7,23 @@
  * # fieldInfo
  */
 angular.module('vlui')
-  .directive('quantitativeFitler', function () {
+  .directive('quantitativeFilter', function (Dataset) {
     return {
       templateUrl: 'components/filter/quantitativefilter.html',
       restrict: 'E',
-      replace: true,
+      replace: false,
       scope: {
-        fieldDef: '='
+        field: '=',
+        filter: '='
       },
       link: function(scope, element) {
-
+        scope.domainMin = 0;
+        scope.domainMax = 100;
+        scope.$watch('field', function(field) {
+          var domain = Dataset.domain(field);
+          scope.domainMin = domain[0];
+          scope.domainMax = domain[1];
+        });
       }
     };
   });

--- a/src/components/filter/quantitativefilter.js
+++ b/src/components/filter/quantitativefilter.js
@@ -17,13 +17,9 @@ angular.module('vlui')
         filter: '='
       },
       link: function(scope, element) {
-        scope.domainMin = 0;
-        scope.domainMax = 100;
-        scope.$watch('field', function(field) {
-          var domain = Dataset.domain(field);
-          scope.domainMin = domain[0];
-          scope.domainMax = domain[1];
-        });
+        var domain = Dataset.domain(scope.field);
+        scope.domainMin = domain[0];
+        scope.domainMax = domain[1];
       }
     };
   });

--- a/src/components/filter/quantitativefilter.scss
+++ b/src/components/filter/quantitativefilter.scss
@@ -1,0 +1,67 @@
+quantitative-filter {
+  .domain-label {
+    padding: 0px 4px;
+    color: gray;
+  }
+
+  // slider general look
+  .ngrs-range-slider {
+    border: none;
+    background: none;
+    box-shadow: none;
+    -webkit-box-shadow: none;
+    margin-top: 0px;
+    margin-bottom: 20px;
+  }
+  .ngrs-range-slider.ngrs-focus {
+    box-shadow: none;
+    -webkit-box-shadow: none;
+  }
+
+  // slider body
+  .ngrs-range-slider {
+    .ngrs-join {
+      background-color: rgba(31, 119, 180, 0.8);
+      background-image: none;
+    }
+
+    .ngrs-runner {
+      background-color: lightgray;
+      border-radius: 3px;
+      height: 8px;
+      margin: 0px 12px;
+    }
+
+    .ngrs-attached-handles {
+      margin: 0px 12px;
+    }
+  }
+
+  // slider labels
+  .ngrs-range-slider {
+    .ngrs-value {
+      color: rgba(31, 119, 180, 0.8);
+      font-size: 11px;
+      text-align: center;
+    }
+  }
+  .ngrs-range-slider.ngrs-handle-min-down,
+  .ngrs-range-slider.ngrs-handle-max-down {
+    .ngrs-value {
+      color: rgba(31, 119, 180, 1);
+    }
+  }
+
+  // slider handles
+  .ngrs-range-slider {
+    .ngrs-handle {
+      background-color: white;
+      height: 18px;
+      width: 10px;
+      margin: -5px 0 0 -5px;
+    }
+    .ngrs-handle i {
+      display: none; 
+    }
+  }
+}

--- a/src/dataset/dataset.service.js
+++ b/src/dataset/dataset.service.js
@@ -113,6 +113,8 @@ angular.module('vlui')
       } else {
         return util.keys(stats.unique)
           .map(function(x) {
+            // Coerce number to become number if they are number,
+            // Otherwise return string.
             if (+x === +x) { return +x; }
             return x;
           }).sort();

--- a/src/dataset/dataset.service.js
+++ b/src/dataset/dataset.service.js
@@ -106,12 +106,18 @@ angular.module('vlui')
 
     // TODO: remove
     Dataset.domain = function(field) {
+      var type = Dataset.schema.type(field);
       var stats = Dataset.schema.stats({field: field});
-      return util.keys(stats.unique)
-        .map(function(x) {
-          if (+x === +x) { return +x; }
-          return x;
-        }).sort();
+      if (type === vl.type.QUANTITATIVE) {
+        return [stats.min, stats.max];
+      } else {
+        return util.keys(stats.unique)
+          .map(function(x) {
+            if (+x === +x) { return +x; }
+            return x;
+          }).sort();
+      }
+
     };
 
     function updateFromData(dataset, data) {

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,8 @@
 angular.module('vlui', [
     'LocalStorageModule',
     'angular-google-analytics',
-    'angular-sortable-view'
+    'angular-sortable-view',
+    'ui-rangeSlider'
   ])
   .constant('_', window._)
   // datalib, vegalite, vega

--- a/src/services/filtermanager/filtermanager.js
+++ b/src/services/filtermanager/filtermanager.js
@@ -39,7 +39,6 @@ angular.module('vlui')
         return filters;
       }, []);
 
-      console.log('Update filter', JSON.stringify(vlFilter, null, 2));
       return vlFilter.length ? vlFilter : undefined;
     }
 


### PR DESCRIPTION
![screen shot 2016-08-05 at 2 24 06 pm](https://cloud.githubusercontent.com/assets/822034/17451258/4e9f2a62-5b1a-11e6-972c-affd46e95988.png)

Diff from kw/q-filter: https://github.com/vega/vega-lite-ui/compare/kw/q-filter...zqu/polish-q-filter

Polish q-filters:
- [x] Use new version of vega-lite
- [x] Hide filter toggle button for `# Count` fields
- [x] Initialize Q filters with correct data domains
- [x] Remove watching `field` change in Q filters (because `field` doesn't really change)
- [x] Show range `min` & `max` as user slides
- [x] Improve Q filter CSS

There is one test case that's failing in master too. I fixed it here: https://github.com/vega/vega-lite-ui/pull/222 I'll rebase after the fix has been merged.
