### PR TITLE
Fix test case as the number of timeUnits in function-select has changed

### DIFF
--- a/src/components/functionselect/functionselect.test.js
+++ b/src/components/functionselect/functionselect.test.js
@@ -63,7 +63,7 @@ describe('Directive: functionSelect', function() {
     element = angular.element('<function-select  field-def="encoding[channel3]" channel="channel3" pills="pills"></function-select>');
     element = $compile(element)(scope);
     scope.$digest();
-    expect(element.find('input').length).to.eql(25);
+    expect(element.find('input').length).to.eql(22);
   });
 
   it('should not show other options for count field', function() {


### PR DESCRIPTION
Test case should expect 22 timeUnits in function-select because that's how many we get from schema. This will be over-written by PR https://github.com/vega/vega-lite-ui/pull/205 where we change the timeUnits in function select again
