### PR TITLE
[WIP] Update CQL's SpecQueryModelGroup methods to match new namespace

### DIFF
--- a/src/components/vlplotgrouplist/vlplotgrouplist.js
+++ b/src/components/vlplotgrouplist/vlplotgrouplist.js
@@ -42,7 +42,7 @@ angular.module('vlui')
         /** return if the plot is still in the view, so it might be omitted from the render queue if necessary. */
         function isInList(chart) {
           for (var i = 0; i < scope.items.length; i++) {
-            if(chart.specM === cql.modelGroup.getTopItem(scope.items[i])) {
+            if(chart.specM === cql.model.SpecQueryModelGroup.getTopSpecQueryModel(scope.items[i])) {
               return true;
             }
           }

--- a/src/services/chart/chart.service.js
+++ b/src/services/chart/chart.service.js
@@ -23,8 +23,8 @@ angular.module('vlui')
         };
       }
 
-      var specM = cql.modelGroup.isSpecQueryModelGroup(item) ?
-        cql.modelGroup.getTopItem(item) :
+      var specM = (item instanceof cql.model.SpecQueryModelGroup) ?
+        cql.model.SpecQueryModelGroup.getTopSpecQueryModel(item) :
         item;
       return {
         enumSpecIndex: specM.enumSpecIndex,


### PR DESCRIPTION
Part of https://github.com/uwdata/compassql/issues/181.
- cql.modelGroup.isSpecQueryModelGroup(item) => (item instanceof cql.model.SpecQueryModelGroup)
- cql.modelGroup.getTopItem(item) => cql.model.SpecQueryModelGroup.getTopSpecQueryModel(item)
