### PR TITLE
Filter timeUnits with cardinality less than or equal to 1 from function select

### DIFF
--- a/src/components/functionselect/functionselect.js
+++ b/src/components/functionselect/functionselect.js
@@ -125,8 +125,9 @@ angular.module('vlui')
           } else {
             // TODO: check supported type based on primitive data?
             function cardinalityFilter(timeUnit) {
-              // don't filter undefined. Remove timeUnits that have cardinality <= 1
-              return !timeUnit ? true : Dataset.schema.cardinality({field: pill.field, channel: 'x', timeUnit: timeUnit}, true, true) > 1;
+              // don't filter undefined. Remove timeUnits that have cardinality <= 1. Convert 'any' channel to '?'.
+              var convertedChannel = Pills.isAnyChannel(scope.channelId) ? '?' : scope.channelId;
+              return !timeUnit ? true : Dataset.schema.cardinality({field: pill.field, channel: convertedChannel, timeUnit: timeUnit}, true, true) > 1;
             }
             if (isT) {
               scope.func.list.aboveFold = temporalFunctions.aboveFold.filter(cardinalityFilter);

--- a/src/components/functionselect/functionselect.js
+++ b/src/components/functionselect/functionselect.js
@@ -126,7 +126,7 @@ angular.module('vlui')
             // TODO: check supported type based on primitive data?
             function cardinalityFilter(timeUnit) {
               // don't filter undefined. Remove timeUnits that have cardinality <= 1
-              return !timeUnit ? true : Dataset.schema.cardinality({field: pill.field, channel: 'x', timeUnit: timeUnit}) > 1;
+              return !timeUnit ? true : Dataset.schema.cardinality({field: pill.field, channel: 'x', timeUnit: timeUnit}, true, true) > 1;
             }
             if (isT) {
               scope.func.list.aboveFold = temporalFunctions.aboveFold.filter(cardinalityFilter);

--- a/src/components/functionselect/functionselect.js
+++ b/src/components/functionselect/functionselect.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('vlui')
-  .directive('functionSelect', function(_, consts, vl, Pills, Logger) {
+  .directive('functionSelect', function(_, consts, vl, Pills, Logger, Dataset) {
     return {
       templateUrl: 'components/functionselect/functionselect.html',
       restrict: 'E',
@@ -126,9 +126,13 @@ angular.module('vlui')
             scope.func.selected = COUNT;
           } else {
             // TODO: check supported type based on primitive data?
+            function cardinalityFilter(timeUnit) {
+              // don't filter undefined. Remove timeUnits that have cardinality <= 1
+              return !timeUnit ? true : Dataset.schema.cardinality({field: pill.field, channel: 'x', timeUnit: timeUnit}) > 1;
+            }
             if (isT) {
-              scope.func.list.aboveFold = temporalFunctions.aboveFold;
-              scope.func.list.belowFold = temporalFunctions.belowFold;
+              scope.func.list.aboveFold = temporalFunctions.aboveFold.filter(cardinalityFilter);
+              scope.func.list.belowFold = temporalFunctions.belowFold.filter(cardinalityFilter);
             }
             else if (isQ) {
               scope.func.list.aboveFold = quantitativeFunctions.aboveFold;

--- a/src/components/functionselect/functionselect.js
+++ b/src/components/functionselect/functionselect.js
@@ -125,9 +125,11 @@ angular.module('vlui')
           } else {
             // TODO: check supported type based on primitive data?
             function cardinalityFilter(timeUnit) {
-              // don't filter undefined. Remove timeUnits that have cardinality <= 1. Convert 'any' channel to '?'.
-              var convertedChannel = Pills.isAnyChannel(scope.channelId) ? '?' : scope.channelId;
-              return !timeUnit ? true : Dataset.schema.cardinality({field: pill.field, channel: convertedChannel, timeUnit: timeUnit}, true, true) > 1;
+              // Convert 'any' channel to '?'.
+              var channel = Pills.isAnyChannel(scope.channelId) ? '?' : scope.channelId;
+              return !timeUnit || // Don't filter undefined.
+                // Remove timeUnits that have cardinality <= 1. 
+                Dataset.schema.cardinality({field: pill.field, channel: channel, timeUnit: timeUnit}, true, true) > 1;
             }
             if (isT) {
               scope.func.list.aboveFold = temporalFunctions.aboveFold.filter(cardinalityFilter);


### PR DESCRIPTION
TimeUnits that would result in (cardinality <= 1) are not shown in the function select menu for temporal fields.

Fix https://github.com/uwdata/voyager2/issues/93
