### PR TITLE
Turn off domain augmenting for generating function list

### DIFF
--- a/src/components/functionselect/functionselect.html
+++ b/src/components/functionselect/functionselect.html
@@ -2,14 +2,14 @@
   <h4>Function</h4>
   <!-- Above the fold functions -->
   <div>
-    <label class="func-label field-func" 
+    <label class="func-label field-func"
       ng-repeat="f in func.list.aboveFold"
       ng-class="{none: !f}">
       <input type="radio" ng-value="f" ng-model="func.selected" ng-change="selectChanged()">
       {{f || 'NONE'}}
     </label>
   </div>
-  
+
   <!-- Below the fold functions -->
   <div ng-show="showAllFunctions">
     <label class="func-label field-func"
@@ -19,11 +19,11 @@
       {{f}}
     </label>
   </div>
-  
+
   <!-- more and less toggles -->
-  <div ng-hide="func.isCount"
+  <div ng-hide="func.isCount || func.list.belowFold.length == 0"
     class="expand-collapse">
-    <a ng-click="showAllFunctions=!showAllFunctions"> 
+    <a ng-click="showAllFunctions=!showAllFunctions">
       <span ng-show="!showAllFunctions"> more <i class="fa fa-angle-down" aria-hidden="true"></i> </span>
       <span ng-show="showAllFunctions"> less <i class="fa fa-angle-up" aria-hidden="true"></i> </span>
     </a>

--- a/src/components/functionselect/functionselect.js
+++ b/src/components/functionselect/functionselect.js
@@ -45,7 +45,7 @@ angular.module('vlui')
           ]
         };
 
-        scope.cardinalityFilter = function(timeUnit) {
+        var cardinalityFilter = function(timeUnit) {
           var field = Pills.get(scope.channelId).field;
           // Convert 'any' channel to '?'.
           var channel = Pills.isAnyChannel(scope.channelId) ? '?' : scope.channelId;
@@ -134,8 +134,8 @@ angular.module('vlui')
           } else {
             // TODO: check supported type based on primitive data?
             if (isT) {
-              scope.func.list.aboveFold = temporalFunctions.aboveFold.filter(scope.cardinalityFilter);
-              scope.func.list.belowFold = temporalFunctions.belowFold.filter(scope.cardinalityFilter);
+              scope.func.list.aboveFold = temporalFunctions.aboveFold.filter(cardinalityFilter);
+              scope.func.list.belowFold = temporalFunctions.belowFold.filter(cardinalityFilter);
             }
             else if (isQ) {
               scope.func.list.aboveFold = quantitativeFunctions.aboveFold;

--- a/src/components/functionselect/functionselect.js
+++ b/src/components/functionselect/functionselect.js
@@ -46,11 +46,12 @@ angular.module('vlui')
         };
 
         scope.cardinalityFilter = function(timeUnit) {
+          var field = Pills.get(scope.channelId).field;
           // Convert 'any' channel to '?'.
           var channel = Pills.isAnyChannel(scope.channelId) ? '?' : scope.channelId;
           return !timeUnit || // Don't filter undefined.
-            // Remove timeUnits that have cardinality <= 1.
-            Dataset.schema.cardinality({field: Pills.get(scope.channelId).field, channel: channel, timeUnit: timeUnit}, false, true) > 1;
+            // Remove timeUnits that do not have variation (cardinality <= 1).
+            Dataset.schema.timeUnitHasVariation({field: field, channel: channel, timeUnit: timeUnit});
         };
 
         // timeUnits = T functions - undefined

--- a/src/components/functionselect/functionselect.js
+++ b/src/components/functionselect/functionselect.js
@@ -45,6 +45,14 @@ angular.module('vlui')
           ]
         };
 
+        function cardinalityFilter(timeUnit) {
+          // Convert 'any' channel to '?'.
+          var channel = Pills.isAnyChannel(scope.channelId) ? '?' : scope.channelId;
+          return !timeUnit || // Don't filter undefined.
+            // Remove timeUnits that have cardinality <= 1.
+            Dataset.schema.cardinality({field: Pills.get(scope.channelId).field, channel: channel, timeUnit: timeUnit}, false, true) > 1;
+        }
+
         // timeUnits = T functions - undefined
         var timeUnits = _.pull(_.concat(temporalFunctions.aboveFold, temporalFunctions.belowFold), undefined);
 
@@ -124,13 +132,6 @@ angular.module('vlui')
             scope.func.selected = COUNT;
           } else {
             // TODO: check supported type based on primitive data?
-            function cardinalityFilter(timeUnit) {
-              // Convert 'any' channel to '?'.
-              var channel = Pills.isAnyChannel(scope.channelId) ? '?' : scope.channelId;
-              return !timeUnit || // Don't filter undefined.
-                // Remove timeUnits that have cardinality <= 1.
-                Dataset.schema.cardinality({field: pill.field, channel: channel, timeUnit: timeUnit}, false, true) > 1;
-            }
             if (isT) {
               scope.func.list.aboveFold = temporalFunctions.aboveFold.filter(cardinalityFilter);
               scope.func.list.belowFold = temporalFunctions.belowFold.filter(cardinalityFilter);

--- a/src/components/functionselect/functionselect.js
+++ b/src/components/functionselect/functionselect.js
@@ -45,13 +45,13 @@ angular.module('vlui')
           ]
         };
 
-        function cardinalityFilter(timeUnit) {
+        scope.cardinalityFilter = function(timeUnit) {
           // Convert 'any' channel to '?'.
           var channel = Pills.isAnyChannel(scope.channelId) ? '?' : scope.channelId;
           return !timeUnit || // Don't filter undefined.
             // Remove timeUnits that have cardinality <= 1.
             Dataset.schema.cardinality({field: Pills.get(scope.channelId).field, channel: channel, timeUnit: timeUnit}, false, true) > 1;
-        }
+        };
 
         // timeUnits = T functions - undefined
         var timeUnits = _.pull(_.concat(temporalFunctions.aboveFold, temporalFunctions.belowFold), undefined);
@@ -133,8 +133,8 @@ angular.module('vlui')
           } else {
             // TODO: check supported type based on primitive data?
             if (isT) {
-              scope.func.list.aboveFold = temporalFunctions.aboveFold.filter(cardinalityFilter);
-              scope.func.list.belowFold = temporalFunctions.belowFold.filter(cardinalityFilter);
+              scope.func.list.aboveFold = temporalFunctions.aboveFold.filter(scope.cardinalityFilter);
+              scope.func.list.belowFold = temporalFunctions.belowFold.filter(scope.cardinalityFilter);
             }
             else if (isQ) {
               scope.func.list.aboveFold = quantitativeFunctions.aboveFold;

--- a/src/components/functionselect/functionselect.js
+++ b/src/components/functionselect/functionselect.js
@@ -128,8 +128,8 @@ angular.module('vlui')
               // Convert 'any' channel to '?'.
               var channel = Pills.isAnyChannel(scope.channelId) ? '?' : scope.channelId;
               return !timeUnit || // Don't filter undefined.
-                // Remove timeUnits that have cardinality <= 1. 
-                Dataset.schema.cardinality({field: pill.field, channel: channel, timeUnit: timeUnit}, true, true) > 1;
+                // Remove timeUnits that have cardinality <= 1.
+                Dataset.schema.cardinality({field: pill.field, channel: channel, timeUnit: timeUnit}, false, true) > 1;
             }
             if (isT) {
               scope.func.list.aboveFold = temporalFunctions.aboveFold.filter(cardinalityFilter);


### PR DESCRIPTION
Non-periodic timeUnit functions that do not produce variation are no longer displayed as options in the function select menu.

Also, multi-timeunits must be distinct in all sub-timeUnits in order to appear on the function list.

Follow up to https://github.com/uwdata/voyager2/issues/93.
