### PR TITLE
Add 'load chart from bookmark' functionality

### DIFF
--- a/src/components/bookmarklist/bookmarklist.html
+++ b/src/components/bookmarklist/bookmarklist.html
@@ -29,6 +29,7 @@
 
         priority="consts.priority.bookmark"
 
+        show-select="true"
         sv-element>
       </vl-plot-group>
       <div sv-placeholder></div>

--- a/src/components/bookmarklist/bookmarklist.html
+++ b/src/components/bookmarklist/bookmarklist.html
@@ -14,7 +14,7 @@
         ng-repeat="bookmark in Bookmarks.list | orderObjectBy : 'timeAdded' : false"
         class="wrapped-vl-plot-group card"
 
-        list-title="Bookmark"
+        list-title="'Bookmark'"
 
         chart="bookmark.chart"
         field-set="bookmark.chart.fieldSet"

--- a/src/components/bookmarklist/bookmarklist.js
+++ b/src/components/bookmarklist/bookmarklist.js
@@ -13,7 +13,8 @@ angular.module('vlui')
       restrict: 'E',
       replace: true,
       scope: {
-        highlighted: '=' // This one is really two-way binding.
+        highlighted: '=', // This one is really two-way binding.
+        postSelectAction: '='
       },
       link: function postLink(scope /*, element, attrs*/) {
         scope.Bookmarks = Bookmarks;

--- a/src/components/vlplotgroup/vlplotgroup.html
+++ b/src/components/vlplotgroup/vlplotgroup.html
@@ -1,5 +1,5 @@
 <div class="vl-plot-group vflex"
-  ng-dblclick="selectAction()"
+  ng-dblclick="select(chart)"
   >
   <div ng-show="showExpand || fieldSet || showTranspose || showBookmark && Bookmarks.isSupported || showToggle"
       class="vl-plot-group-header no-shrink"

--- a/src/components/vlplotgroup/vlplotgroup.html
+++ b/src/components/vlplotgroup/vlplotgroup.html
@@ -84,7 +84,7 @@
       </a>
       <a ng-if="showSelect"
         title="Select this encoding"
-        ng-click="selectAction()"
+        ng-click="select(chart)"
         class="command select">
         <i class="fa fa-server"></i>
       </a>

--- a/src/components/vlplotgroup/vlplotgroup.js
+++ b/src/components/vlplotgroup/vlplotgroup.js
@@ -170,8 +170,8 @@ angular.module('vlui')
             list: scope.listTitle
           });
           Pills.parse(chart.vlSpec);
-          if (scope.postSelectAction) {
-            scope.postSelectAction();
+          if (scope.$parent.postSelectAction) {
+            scope.$parent.postSelectAction();
           }
           Modals.close('bookmark-list');
         };

--- a/src/components/vlplotgroup/vlplotgroup.js
+++ b/src/components/vlplotgroup/vlplotgroup.js
@@ -56,7 +56,8 @@ angular.module('vlui')
         alwaysSelected: '<',
         isSelected: '<',
         highlighted: '<',
-        expandAction: '&'
+        expandAction: '&',
+        selectAction: '&'
       },
       link: function postLink(scope) {
         scope.Bookmarks = Bookmarks;

--- a/src/components/vlplotgroup/vlplotgroup.js
+++ b/src/components/vlplotgroup/vlplotgroup.js
@@ -7,7 +7,7 @@
  * # visListItem
  */
 angular.module('vlui')
-  .directive('vlPlotGroup', function (Bookmarks, consts, vg, vl, Dataset, Logger, _, Pills, Chart, $timeout) {
+  .directive('vlPlotGroup', function (Bookmarks, consts, vg, vl, Dataset, Logger, _, Pills, Chart, $timeout, Modals) {
     return {
       templateUrl: 'components/vlplotgroup/vlplotgroup.html',
       restrict: 'E',
@@ -151,6 +151,17 @@ angular.module('vlui')
             }
           }
           return false;
+        };
+
+        scope.select = function(chart) {
+          Logger.logInteraction(Logger.actions.SPEC_SELECT, chart.shorthand, {
+            list: scope.listTitle
+          });
+          Pills.parse(chart.vlSpec);
+          if (scope.postSelectAction) {
+            scope.postSelectAction();
+          }
+          Modals.close('bookmark-list');
         };
 
         scope.removeBookmark = function(chart) {

--- a/src/components/vlplotgroup/vlplotgroup.js
+++ b/src/components/vlplotgroup/vlplotgroup.js
@@ -171,7 +171,7 @@ angular.module('vlui')
           if (scope.$parent.postSelectAction) {
             scope.$parent.postSelectAction();
           }
-          Modals.close('bookmark-list');
+          Modals.close('bookmark-list'); // HACK: this line is only necessary when this function is called from bookmark list
         };
 
         scope.removeBookmark = function(chart) {

--- a/src/components/vlplotgroup/vlplotgroup.js
+++ b/src/components/vlplotgroup/vlplotgroup.js
@@ -58,8 +58,7 @@ angular.module('vlui')
         alwaysSelected: '<',
         isSelected: '<',
         highlighted: '<',
-        expandAction: '&',
-        selectAction: '&'
+        expandAction: '&'
       },
       link: function postLink(scope) {
         scope.Bookmarks = Bookmarks;

--- a/src/components/vlplotgrouplist/vlplotgrouplist.html
+++ b/src/components/vlplotgrouplist/vlplotgrouplist.html
@@ -25,7 +25,6 @@
       tooltip="true"
 
       highlighted="Pills.highlighted"
-      select-action="select(chart)"
       priority="priority + $index"
     >
     </vl-plot-group>

--- a/src/components/vlplotgrouplist/vlplotgrouplist.js
+++ b/src/components/vlplotgrouplist/vlplotgrouplist.js
@@ -25,7 +25,6 @@ angular.module('vlui')
         scope.getChart = Chart.getChart;
         scope.increaseLimit = increaseLimit;
         scope.isInlist = isInList;
-        scope.select = select;
         scope.Pills = Pills;
 
         // element.bind('scroll', function(){
@@ -51,16 +50,6 @@ angular.module('vlui')
             }
           }
           return false;
-        }
-
-        function select(chart) {
-          Logger.logInteraction(Logger.actions.SPEC_SELECT, chart.shorthand, {
-            list: scope.listTitle
-          });
-          Pills.parse(chart.vlSpec);
-          if (scope.postSelectAction) {
-            scope.postSelectAction();
-          }
         }
       }
     };


### PR DESCRIPTION
Clicking the 'select' icon on a bookmarked chart in the bookmarks list causes it to be loaded as the main viz. 

Fix https://github.com/uwdata/voyager2/issues/94
