### PR TITLE
Move type popup from channel shelf to schema list item

### DIFF
--- a/src/components/channelshelf/channelshelf.html
+++ b/src/components/channelshelf/channelshelf.html
@@ -82,14 +82,6 @@
     <div class="popup-menu shelf-functions shelf-functions-{{channelId}}">
       <function-select ng-if="!preview" field-def="encoding[channelId]" channel-id="channelId"></function-select>
 
-      <div class="mb5" ng-if="allowedTypes.length>1">
-        <h4>Type</h4>
-        <label class="type-label"
-          ng-repeat="type in allowedTypes">
-          <input type="radio" ng-value="type" ng-model="encoding[channelId].type">
-          {{type}}
-        </label>
-      </div>
       <!-- <a class="remove-field" ng-click="removeField()">Remove Field</a> -->
     </div>
   </div>

--- a/src/components/channelshelf/channelshelf.js
+++ b/src/components/channelshelf/channelshelf.js
@@ -14,17 +14,6 @@ angular.module('vlui')
         disabled: '<'
       },
       link: function(scope, element /*, attrs*/) {
-        var propsPopup;
-
-        // TODO(https://github.com/vega/vega-lite-ui/issues/187):
-        // consider if we can use validator / cql instead
-        scope.allowedCasting = {
-          quantitative: [vl.type.QUANTITATIVE, vl.type.ORDINAL, vl.type.NOMINAL],
-          ordinal: [vl.type.ORDINAL, vl.type.NOMINAL],
-          nominal: [vl.type.NOMINAL, vl.type.ORDINAL],
-          temporal: [vl.type.TEMPORAL, vl.type.ORDINAL, vl.type.NOMINAL]
-        };
-
         scope.Dataset = Dataset;
         scope.schema = Schema.getChannelSchema(scope.channelId);
         scope.pills = Pills.pills;
@@ -49,7 +38,7 @@ angular.module('vlui')
           return vl.channel.supportMark(channelId, mark);
         };
 
-        propsPopup = new Drop({
+        var propsPopup = new Drop({
           content: element.find('.shelf-properties')[0],
           target: element.find('.shelf-label')[0],
           position: 'bottom left',
@@ -106,10 +95,6 @@ angular.module('vlui')
           }
         }, true);
 
-        scope.$watchGroup(['allowedCasting[Dataset.schema.type(encoding[channelId].field)]', 'encoding[channel].aggregate'], function(arr){
-          var allowedTypes = arr[0], aggregate=arr[1];
-          scope.allowedTypes = aggregate === 'count' ? [vl.type.QUANTITATIVE] : allowedTypes;
-        });
 
         scope.$on('$destroy', function() {
           if (propsPopup && propsPopup.destroy) {

--- a/src/components/channelshelf/channelshelf.scss
+++ b/src/components/channelshelf/channelshelf.scss
@@ -31,8 +31,6 @@ $text-color: #212121;
     background-color: hsla(185,80%,29%,0.4);
   }
 
-
-
   .shelf-label {
     @extend .noselect;
     display: block;

--- a/src/components/schemalist/schemalistitem.html
+++ b/src/components/schemalist/schemalistitem.html
@@ -10,7 +10,23 @@
   data-jqyoui-options="{revert: 'invalid', helper: 'clone'}"
 
   show-add='showAdd'
+  show-caret="true"
+  disable-caret="fieldDef.immutable || fieldDef.aggregate === 'count' || allowedTypes.length<=1"
   show-type="true"
   add-action="fieldAdd(fieldDef)"
+
+  popup-content="fieldInfoPopupContent"
   >
 </field-info>
+<div class="drop-container">
+  <div class="popup-menu schema-menu">
+    <div class="mb5 field-type" ng-if="allowedTypes.length>1 && !isAnyField">
+      <h4>Type</h4>
+      <label class="type-label"
+        ng-repeat="type in allowedTypes">
+        <input type="radio" ng-value="type" ng-model="fieldDef.type">
+        {{type}}
+      </label>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
@RileyChang  I figure that I should do this for you as I need it for another thing I'm doing.

That said, I notice that we still need to 
- [ ] eliminate `Dataset.dataschema` and just use `Dataset.schema`
- [ ] Change the `allowTypes` to be based on `primitiveType` instead

Please do that for me in a follow-up PR.  

Fix https://github.com/uwdata/voyager2/issues/73
