### PR TITLE
Save text annotations once per second instead per keystroke

### DIFF
--- a/src/services/bookmarks/bookmarks.service.js
+++ b/src/services/bookmarks/bookmarks.service.js
@@ -21,11 +21,11 @@ angular.module('vlui')
       localStorageService.set('bookmarkList', this.list);
     };
 
-    proto.saveAnnotations = function(shorthand) {
+    proto.saveAnnotations = _.throttle(function(shorthand) {
       _.find(this.list, function(bookmark) { return bookmark.shorthand === shorthand; })
         .chart.annotation = this.dict[shorthand].annotation;
       this.save();
-    };
+    }, 1000, {"trailing": true});
 
     // export all bookmarks and annotations
     proto.export = function() {


### PR DESCRIPTION
Instead of saving text annotations once per keystroke, use throttle do save them once per second

Fix https://github.com/uwdata/voyager2/issues/118
