### PR TITLE
Determine allowed types from primitive types

### DIFF
--- a/src/components/schemalist/schemalistitem.html
+++ b/src/components/schemalist/schemalistitem.html
@@ -19,7 +19,7 @@
   >
 </field-info>
 <div class="drop-container">
-  <div class="popup-menu schema-menu">
+  <div class="popup-menu schema-menu" ng-hide="allowedTypes.length<=1">
     <div class="mb5 field-type" ng-if="allowedTypes.length>1 && !isAnyField">
       <h4>Type</h4>
       <label class="type-label"

--- a/src/components/schemalist/schemalistitem.js
+++ b/src/components/schemalist/schemalistitem.js
@@ -44,10 +44,11 @@ angular.module('vlui')
         // TODO(https://github.com/vega/vega-lite-ui/issues/187):
         // consider if we can use validator / cql instead
         var allowedCasting = {
-          quantitative: [vl.type.QUANTITATIVE, vl.type.ORDINAL, vl.type.NOMINAL],
-          ordinal: [vl.type.ORDINAL, vl.type.NOMINAL],
-          nominal: [vl.type.NOMINAL, vl.type.ORDINAL],
-          temporal: [vl.type.TEMPORAL, vl.type.ORDINAL, vl.type.NOMINAL],
+          integer: [vl.type.QUANTITATIVE, vl.type.ORDINAL, vl.type.NOMINAL],
+          number: [vl.type.QUANTITATIVE, vl.type.ORDINAL, vl.type.NOMINAL],
+          date: [vl.TEMPORAL, vl.type.NOMINAL, vl.type.ORDINAL],
+          string: [vl.type.ORDINAL, vl.type.NOMINAL],
+          boolean: [vl.type.ORDINAL, vl.type.NOMINAL],
           all: [vl.type.QUANTITATIVE, vl.type.TEMPORAL, vl.type.ORDINAL, vl.type.NOMINAL]
         };
 
@@ -55,7 +56,7 @@ angular.module('vlui')
           if (cql.enumSpec.isEnumSpec(fieldDef.field)) {
             scope.allowedTypes = allowedCasting.all;
           } else {
-            scope.allowedTypes = allowedCasting[Dataset.schema.type(fieldDef.field)];
+            scope.allowedTypes = allowedCasting[Dataset.schema.primitiveType(fieldDef.field)];
           }
 
           scope.isAnyField = cql.enumSpec.isEnumSpec(fieldDef.field);

--- a/src/components/schemalist/schemalistitem.js
+++ b/src/components/schemalist/schemalistitem.js
@@ -46,8 +46,8 @@ angular.module('vlui')
         var allowedCasting = {
           integer: [vl.type.QUANTITATIVE, vl.type.ORDINAL, vl.type.NOMINAL],
           number: [vl.type.QUANTITATIVE, vl.type.ORDINAL, vl.type.NOMINAL],
-          date: [vl.TEMPORAL, vl.type.NOMINAL, vl.type.ORDINAL],
-          string: [vl.type.ORDINAL, vl.type.NOMINAL],
+          date: [vl.TEMPORAL],
+          string: [vl.type.NOMINAL],
           boolean: [vl.type.ORDINAL, vl.type.NOMINAL],
           all: [vl.type.QUANTITATIVE, vl.type.TEMPORAL, vl.type.ORDINAL, vl.type.NOMINAL]
         };

--- a/src/components/schemalist/schemalistitem.js
+++ b/src/components/schemalist/schemalistitem.js
@@ -48,7 +48,7 @@ angular.module('vlui')
           number: [vl.type.QUANTITATIVE, vl.type.ORDINAL, vl.type.NOMINAL],
           date: [vl.TEMPORAL],
           string: [vl.type.NOMINAL],
-          boolean: [vl.type.ORDINAL, vl.type.NOMINAL],
+          boolean: [vl.type.NOMINAL],
           all: [vl.type.QUANTITATIVE, vl.type.TEMPORAL, vl.type.ORDINAL, vl.type.NOMINAL]
         };
 


### PR DESCRIPTION
When manually changing a field's type, the available types are now determined based on the field's primitive type instead of its previous type. For instance, the `cylinders` field from cars.json can now be changed to Q.

Part of issue https://github.com/uwdata/voyager2/issues/126
