### PR TITLE
Remove Dataset.dataschema 

### DIFF
--- a/src/components/schemalist/schemalistitem.js
+++ b/src/components/schemalist/schemalistitem.js
@@ -53,7 +53,6 @@ angular.module('vlui')
         };
 
         var unwatchFieldDef = scope.$watch('fieldDef', function(fieldDef){
-          console.log(fieldDef);
           if (cql.enumSpec.isEnumSpec(fieldDef.field)) {
             scope.allowedTypes = allowedCasting.all;
           } else {

--- a/src/components/schemalist/schemalistitem.js
+++ b/src/components/schemalist/schemalistitem.js
@@ -55,7 +55,7 @@ angular.module('vlui')
           if (cql.enumSpec.isEnumSpec(fieldDef.field)) {
             scope.allowedTypes = allowedCasting.all;
           } else {
-            scope.allowedTypes = allowedCasting[Dataset.schema.type(fieldDef.field)];
+            scope.allowedTypes = allowedCasting[fieldDef.type];
           }
 
           scope.isAnyField = cql.enumSpec.isEnumSpec(fieldDef.field);

--- a/src/components/schemalist/schemalistitem.js
+++ b/src/components/schemalist/schemalistitem.js
@@ -53,10 +53,11 @@ angular.module('vlui')
         };
 
         var unwatchFieldDef = scope.$watch('fieldDef', function(fieldDef){
+          console.log(fieldDef);
           if (cql.enumSpec.isEnumSpec(fieldDef.field)) {
             scope.allowedTypes = allowedCasting.all;
           } else {
-            scope.allowedTypes = allowedCasting[fieldDef.type];
+            scope.allowedTypes = allowedCasting[fieldDef.primitiveType];
           }
 
           scope.isAnyField = cql.enumSpec.isEnumSpec(fieldDef.field);

--- a/src/dataset/dataset.service.js
+++ b/src/dataset/dataset.service.js
@@ -10,7 +10,6 @@ angular.module('vlui')
     Dataset.datasets = datasets;
     Dataset.dataset = datasets[1];
     Dataset.currentDataset = undefined;  // dataset before update
-    Dataset.dataschema = [];
     Dataset.stats = {};
     Dataset.type = undefined;
 
@@ -111,9 +110,6 @@ angular.module('vlui')
 
       Dataset.schema = cql.schema.Schema.build(data);
       // TODO: find all reference of Dataset.stats.sample and replace
-
-      // TODO: find all reference of Dataset.dataschema and replace
-      Dataset.dataschema = getFieldDefs(Dataset.schema);
     }
 
     Dataset.add = function(dataset) {


### PR DESCRIPTION
Remove the outdated method of using `Dataset.dataschema` and instead simply use `Dataset.schema`.

Needs to be merged AFTER: https://github.com/uwdata/voyager2/pull/154

Part of issue: https://github.com/uwdata/voyager2/issues/126 
