### PR TITLE
Update filter on slider handle release

### DIFF
--- a/src/components/filter/quantitativefilter.html
+++ b/src/components/filter/quantitativefilter.html
@@ -3,9 +3,10 @@
     <span class="right domain-label">{{domainMax}}</span>
     <span class="domain-label">{{domainMin}}</span>
   </div>
-  <div range-slider min="domainMin"" max="domainMax" 
-    model-min="filter.range[0]" model-max="filter.range[1]"
-    show-values="true" attach-handle-values="true">
+  <div range-slider min="domainMin" max="domainMax"
+    model-min="localMin" model-max="localMax"
+    show-values="true" attach-handle-values="true"
+    on-handle-up="updateRange()">
   </div>
 </div>
 

--- a/src/components/filter/quantitativefilter.js
+++ b/src/components/filter/quantitativefilter.js
@@ -21,15 +21,14 @@ angular.module('vlui')
         scope.domainMin = domain[0];
         scope.domainMax = domain[1];
 
-        var unwatchRange = scope.$watch('filter.range', function(range, oldRange) {
-          if (!oldRange || !range || (range === oldRange)) return; // skip first time
+        // don't update until range slider handle released
+        scope.localMin = scope.filter.range[0];
+        scope.localMax = scope.filter.range[1];
+        scope.updateRange = function() {
+          scope.filter.range[0] = scope.localMin;
+          scope.filter.range[1] = scope.localMax;
           Logger.logInteraction(Logger.actions.FILTER_CHANGE, scope.field, scope.filter);
-        }, true);
-
-        scope.$on('$destroy', function() {
-          // Clean up watcher
-          unwatchRange();
-        });
+        };
       }
     };
   });

--- a/src/components/filter/quantitativefilter.js
+++ b/src/components/filter/quantitativefilter.js
@@ -27,6 +27,7 @@ angular.module('vlui')
         scope.updateRange = function() {
           scope.filter.range[0] = scope.localMin;
           scope.filter.range[1] = scope.localMax;
+          scope.$apply();
           Logger.logInteraction(Logger.actions.FILTER_CHANGE, scope.field, scope.filter);
         };
       }

--- a/src/components/filter/quantitativefilter.js
+++ b/src/components/filter/quantitativefilter.js
@@ -27,7 +27,7 @@ angular.module('vlui')
         scope.updateRange = function() {
           scope.filter.range[0] = scope.localMin;
           scope.filter.range[1] = scope.localMax;
-          scope.$apply();
+          scope.$apply(); // Force watcher to observe change
           Logger.logInteraction(Logger.actions.FILTER_CHANGE, scope.field, scope.filter);
         };
       }


### PR DESCRIPTION
Apply Q filter changes on range slider release instead of whenever it is moved.

Part of https://github.com/uwdata/voyager2/issues/175
