### PR TITLE
Log BOOKMARK_ANNOTATE event

### DIFF
--- a/src/components/vlplotgroup/vlplotgroup.html
+++ b/src/components/vlplotgroup/vlplotgroup.html
@@ -128,7 +128,7 @@
   <textarea class="annotation"
     ng-if="Bookmarks.isBookmarked(chart.shorthand)"
     ng-model="Bookmarks.dict[chart.shorthand].annotation"
-    ng-change="Bookmarks.saveAnnotations(chart.shorthand)"
+    ng-blur="Bookmarks.saveAnnotations(chart.shorthand)"
     placeholder = "notes"
   ></textarea>
 </div>

--- a/src/services/bookmarks/bookmarks.service.js
+++ b/src/services/bookmarks/bookmarks.service.js
@@ -10,7 +10,7 @@
 angular.module('vlui')
   .service('Bookmarks', function(_, vl, localStorageService, Logger, Dataset) {
     var Bookmarks = function() {
-      this.list = [];
+      this.list = []; // save to local storage
       this.dict = {};
       this.isSupported = localStorageService.isSupported;
     };
@@ -22,9 +22,11 @@ angular.module('vlui')
     };
 
     proto.saveAnnotations = _.throttle(function(shorthand) {
+      var annotation = this.dict[shorthand].annotation;
       _.find(this.list, function(bookmark) { return bookmark.shorthand === shorthand; })
-        .chart.annotation = this.dict[shorthand].annotation;
+        .chart.annotation = annotation;
       this.save();
+      Logger.logInteraction(Logger.actions.BOOKMARK_ANNOTATE, shorthand, annotation);
     }, 1000, {trailing: true});
 
     // export all bookmarks and annotations

--- a/src/services/bookmarks/bookmarks.service.js
+++ b/src/services/bookmarks/bookmarks.service.js
@@ -21,13 +21,13 @@ angular.module('vlui')
       localStorageService.set('bookmarkList', this.list);
     };
 
-    proto.saveAnnotations = _.throttle(function(shorthand) {
+    proto.saveAnnotations = function(shorthand) {
       var annotation = this.dict[shorthand].annotation;
       _.find(this.list, function(bookmark) { return bookmark.shorthand === shorthand; })
         .chart.annotation = annotation;
       this.save();
       Logger.logInteraction(Logger.actions.BOOKMARK_ANNOTATE, shorthand, annotation);
-    }, 1000, {trailing: true});
+    };
 
     // export all bookmarks and annotations
     proto.export = function() {

--- a/src/services/logger/logger.service.js
+++ b/src/services/logger/logger.service.js
@@ -37,6 +37,7 @@ angular.module('vlui')
       BOOKMARK_OPEN: {category: 'BOOKMARK', id:'BOOKMARK_OPEN', level: service.levels.INFO},
       BOOKMARK_CLOSE: {category: 'BOOKMARK', id:'BOOKMARK_CLOSE', level: service.levels.INFO},
       BOOKMARK_CLEAR: {category: 'BOOKMARK', id: 'BOOKMARK_CLEAR', level: service.levels.INFO},
+      BOOKMARK_ANNOTATE: {category: 'BOOKMARK', id: 'BOOKMARK_ANNOTATE', level: service.levels.INFO},
       // CHART
       CHART_MOUSEOVER: {category: 'CHART', id:'CHART_MOUSEOVER', level: service.levels.DEBUG},
       CHART_MOUSEOUT: {category: 'CHART', id:'CHART_MOUSEOUT', level: service.levels.DEBUG},


### PR DESCRIPTION
When user finishes typing annotation, log `BOOKMARK_ANNOTATE` event and save to local storage. 

Fix https://github.com/uwdata/voyager2/issues/187
- [x] Log `BOOKMARK_ANNOTATE` event, `label` is spec shorthand and `data` is the actual text annotation.
- [x] Use `ng-blur` instead of `_.throttle` so that we log and save annotations less frequently
- [x] Tested with PoleStar
- [x] Tested with Voyager-II

Sample log:

``` csv
userid,time,actionCategory,actionId,label,data
undefined,2016-08-31T18:19:49.430Z,BOOKMARK,BOOKMARK_ANNOTATE,"bar|x:count(*,q,axis={""orient"":""top""})|y:Name,n,scale={""bandSize"":12}","""annotation 1"""
undefined,2016-08-31T18:19:56.852Z,BOOKMARK,BOOKMARK_ANNOTATE,"bar|x:count(*,q)|y:Origin,n","""annotation 2 blah blah"""
undefined,2016-08-31T18:20:10.057Z,BOOKMARK,BOOKMARK_ANNOTATE,"bar|x:count(*,q)|y:Cylinders,o","""annotation 3 blah blah haha"""
```
