### PR TITLE
More compact Encoding + Filter Panes

### DIFF
--- a/src/components/channelshelf/channelshelf.scss
+++ b/src/components/channelshelf/channelshelf.scss
@@ -7,7 +7,7 @@ $text-color: #212121;
 .shelf-group{
   border: 1px solid #ddd;
   border-radius: $pill-radius;
-  margin-bottom: 5px;
+  margin-bottom: 2px;
   font-size: 11px;
 }
 

--- a/src/components/channelshelf/channelshelf.scss
+++ b/src/components/channelshelf/channelshelf.scss
@@ -7,7 +7,7 @@ $text-color: #212121;
 .shelf-group{
   border: 1px solid #ddd;
   border-radius: $pill-radius;
-  margin-bottom: 2px;
+  margin-bottom: 4px;
   font-size: 11px;
 }
 

--- a/src/components/filter/filtershelves.html
+++ b/src/components/filter/filtershelves.html
@@ -15,13 +15,14 @@
         -->
 
         <!-- ng-show="encoding[channelId].field"-->
+        <!-- (zening): remove draggable class for now because filter is not yet draggable -->
         <field-info
           ng-class="{expanded: funcsExpanded}"
           field-def="{field: field}"
           show-type="true"
           show-remove="true"
           remove-action="removeFilter(field)"
-          class="selected draggable full-width"
+          class="selected full-width"
           >
           <!--
           remove-action=""

--- a/src/components/filter/filtershelves.html
+++ b/src/components/filter/filtershelves.html
@@ -1,56 +1,58 @@
 <a class="right"  ng-click="clearFilter()"><i class="fa fa-eraser"></i> Clear</a>
 <h2>Filter</h2>
-<div class="shelf-group"
+<div class="filter-scroll-y-container">
+  <div class="shelf-group"
     ng-repeat="(field, filter) in filterManager.filterIndex"
     ng-if="filter.enabled"
   >
-  <div class="shelf filter-shelf">
-    <div class="field-drop">
-      <!-- TODO: make it drag-and-drop like typical shelf -->
-      <!--
-        data-drop="supportMark(channelId, mark)"
-        jqyoui-droppable="{onDrop:'fieldDropped'}"
-        data-jqyoui-options="{activeClass: 'drop-active'}"
-      -->
-
-      <!-- ng-show="encoding[channelId].field"-->
-      <field-info
-        ng-class="{expanded: funcsExpanded}"
-        field-def="{field: field}"
-        show-type="true"
-        show-remove="true"
-        remove-action="removeFilter(field)"
-        class="selected draggable full-width"
-        >
+    <div class="shelf filter-shelf">
+      <div class="field-drop">
+        <!-- TODO: make it drag-and-drop like typical shelf -->
         <!--
-        remove-action=""
-          data-drag="true"
-          ng-model="pills[channelId]"
-          jqyoui-draggable="{onStart: 'fieldDragStart', onStop:'fieldDragStop'}"
-          data-jqyoui-options="{revert: 'invalid', helper: 'clone'}"
+          data-drop="supportMark(channelId, mark)"
+          jqyoui-droppable="{onDrop:'fieldDropped'}"
+          data-jqyoui-options="{activeClass: 'drop-active'}"
         -->
-      </field-info>
 
-      <!--<span class="placeholder" ng-if="!encoding[channelId].field">
-        drop a field here
-      </span>-->
-    </div>
-    <categorical-filter
-      field="field"
-      filter="filter"
-      ng-if="Dataset.schema.type(field) === 'nominal' || Dataset.schema.type(field) === 'ordinal'
-    "></categorical-filter>
-    <quantitative-filter
-      field="field"
-      filter="filter"
-      ng-if="Dataset.schema.type(field) === 'quantitative'"
-    ></quantitative-filter>
-    <div
-      field="field"
-      filter="filter"
-      ng-if="Dataset.schema.type(field) === 'temporal'"
-      >
-      {{field}} is a temporal field and we do not support filter for temporal field yet.
+        <!-- ng-show="encoding[channelId].field"-->
+        <field-info
+          ng-class="{expanded: funcsExpanded}"
+          field-def="{field: field}"
+          show-type="true"
+          show-remove="true"
+          remove-action="removeFilter(field)"
+          class="selected draggable full-width"
+          >
+          <!--
+          remove-action=""
+            data-drag="true"
+            ng-model="pills[channelId]"
+            jqyoui-draggable="{onStart: 'fieldDragStart', onStop:'fieldDragStop'}"
+            data-jqyoui-options="{revert: 'invalid', helper: 'clone'}"
+          -->
+        </field-info>
+
+        <!--<span class="placeholder" ng-if="!encoding[channelId].field">
+          drop a field here
+        </span>-->
+      </div>
+      <categorical-filter
+        field="field"
+        filter="filter"
+        ng-if="Dataset.schema.type(field) === 'nominal' || Dataset.schema.type(field) === 'ordinal'
+      "></categorical-filter>
+      <quantitative-filter
+        field="field"
+        filter="filter"
+        ng-if="Dataset.schema.type(field) === 'quantitative'"
+      ></quantitative-filter>
+      <div
+        field="field"
+        filter="filter"
+        ng-if="Dataset.schema.type(field) === 'temporal'"
+        >
+        {{field}} is a temporal field and we do not support filter for temporal field yet.
+      </div>
     </div>
   </div>
 </div>

--- a/src/components/filter/filtershelves.scss
+++ b/src/components/filter/filtershelves.scss
@@ -1,3 +1,12 @@
+.filter-scroll-y-container {
+  overflow-y: scroll;
+  position: absolute;
+  top: 30px;
+  bottom: 0;
+  left: 0;
+  right: 0;
+}
+
 .shelf.filter-shelf {
   display: flex;
   flex-direction: column;

--- a/src/components/shelves/shelves.html
+++ b/src/components/shelves/shelves.html
@@ -1,4 +1,4 @@
-<div class="card shelves no-top-margin no-right-margin abs-100">
+<div class="card vflex shelves no-top-margin no-right-margin abs-100">
   <div class="shelf-pane shelf-encoding-pane full-width">
     <a class="right"  ng-click="clear()"><i class="fa fa-eraser"></i> Clear</a>
     <h2>Encoding</h2>

--- a/src/components/shelves/shelves.html
+++ b/src/components/shelves/shelves.html
@@ -1,92 +1,94 @@
 <div class="card shelves no-top-margin no-right-margin abs-100">
-  <a class="right"  ng-click="clear()"><i class="fa fa-eraser"></i> Clear</a>
-  <h2>Encoding</h2>
-
   <div class="shelf-pane shelf-encoding-pane full-width">
-    <h3>Positional</h3>
-    <channel-shelf
-      channel-id="'x'"
-      preview="preview"
-      encoding="spec.encoding"
-      support-any="supportAny"
-      mark="spec.mark">
-    </channel-shelf>
-    <channel-shelf
-      channel-id="'y'"
-      preview="preview"
-      encoding="spec.encoding"
-      support-any="supportAny"
-      mark="spec.mark">
-    </channel-shelf>
-    <channel-shelf
-      channel-id="'column'"
-      preview="preview"
-      encoding="spec.encoding"
-      support-any="supportAny"
-      mark="spec.mark"
-      disabled="!spec.encoding.x.field">
-    >
-    </channel-shelf>
-    <channel-shelf
-      channel-id="'row'"
-      preview="preview"
-      encoding="spec.encoding"
-      support-any="supportAny"
-      mark="spec.mark"
-      disabled="!spec.encoding.y.field">
-    </channel-shelf>
-  </div>
-  <div class="shelf-pane shelf-marks-pane full-width">
-    <div class="right">
-      <select class="markselect" ng-model="spec.mark"
-              ng-class="{auto: spec.mark === ANY}"
-              ng-options="(type === ANY ? 'auto' : type) for type in (supportAny || supportAutoMark ? marksWithAny : marks)"
-              ng-change="markChange()"></select>
+    <a class="right"  ng-click="clear()"><i class="fa fa-eraser"></i> Clear</a>
+    <h2>Encoding</h2>
+
+    <div class="shelf-pane shelf-positional-pane full-width">
+      <h3>Positional</h3>
+      <channel-shelf
+        channel-id="'x'"
+        preview="preview"
+        encoding="spec.encoding"
+        support-any="supportAny"
+        mark="spec.mark">
+      </channel-shelf>
+      <channel-shelf
+        channel-id="'y'"
+        preview="preview"
+        encoding="spec.encoding"
+        support-any="supportAny"
+        mark="spec.mark">
+      </channel-shelf>
+      <channel-shelf
+        channel-id="'column'"
+        preview="preview"
+        encoding="spec.encoding"
+        support-any="supportAny"
+        mark="spec.mark"
+        disabled="!spec.encoding.x.field">
+      >
+      </channel-shelf>
+      <channel-shelf
+        channel-id="'row'"
+        preview="preview"
+        encoding="spec.encoding"
+        support-any="supportAny"
+        mark="spec.mark"
+        disabled="!spec.encoding.y.field">
+      </channel-shelf>
     </div>
-    <h3>Marks</h3>
 
-    <channel-shelf channel-id="'size'"
-      preview="preview"
-      encoding="spec.encoding"
-      support-any="supportAny"
-      mark="spec.mark">
-    </channel-shelf>
-    <channel-shelf channel-id="'color'"
-      preview="preview"
-      encoding="spec.encoding"
-      support-any="supportAny"
-      mark="spec.mark">
-    </channel-shelf>
-    <channel-shelf channel-id="'shape'"
-      preview="preview"
-      encoding="spec.encoding"
-      support-any="supportAny"
-      mark="spec.mark">
-    </channel-shelf>
-    <channel-shelf channel-id="'detail'"
-      preview="preview"
-      encoding="spec.encoding"
-      support-any="supportAny"
-      mark="spec.mark">
-    </channel-shelf>
-    <channel-shelf channel-id="'text'"
-      preview="preview"
-      encoding="spec.encoding"
-      support-any="supportAny"
-      mark="spec.mark">
-    </channel-shelf>
-  </div>
+    <div class="shelf-pane shelf-marks-pane full-width">
+      <div class="right">
+        <select class="markselect" ng-model="spec.mark"
+                ng-class="{auto: spec.mark === ANY}"
+                ng-options="(type === ANY ? 'auto' : type) for type in (supportAny || supportAutoMark ? marksWithAny : marks)"
+                ng-change="markChange()"></select>
+      </div>
+      <h3>Marks</h3>
+      <channel-shelf channel-id="'size'"
+        preview="preview"
+        encoding="spec.encoding"
+        support-any="supportAny"
+        mark="spec.mark">
+      </channel-shelf>
+      <channel-shelf channel-id="'color'"
+        preview="preview"
+        encoding="spec.encoding"
+        support-any="supportAny"
+        mark="spec.mark">
+      </channel-shelf>
+      <channel-shelf channel-id="'shape'"
+        preview="preview"
+        encoding="spec.encoding"
+        support-any="supportAny"
+        mark="spec.mark">
+      </channel-shelf>
+      <channel-shelf channel-id="'detail'"
+        preview="preview"
+        encoding="spec.encoding"
+        support-any="supportAny"
+        mark="spec.mark">
+      </channel-shelf>
+      <channel-shelf channel-id="'text'"
+        preview="preview"
+        encoding="spec.encoding"
+        support-any="supportAny"
+        mark="spec.mark">
+      </channel-shelf>
+    </div>
 
-  <div class="shelf-pane shelf-any-pane full-width" ng-if="supportAny && !preview">
-    <h3>Automatic</h3>
-    <channel-shelf
-      ng-repeat="channelId in anyChannelIds"
-      preview="preview"
-      channel-id="channelId"
-      encoding="spec.encoding"
-      support-any="supportAny"
-      mark="spec.mark">
-    </channel-shelf>
+    <div class="shelf-pane shelf-any-pane full-width" ng-if="supportAny && !preview">
+      <h3>Automatic</h3>
+      <channel-shelf
+        ng-repeat="channelId in anyChannelIds"
+        preview="preview"
+        channel-id="channelId"
+        encoding="spec.encoding"
+        support-any="supportAny"
+        mark="spec.mark">
+      </channel-shelf>
+    </div>
   </div>
 
   <div class="shelf-pane shelf-filter-pane full-width" ng-if="!preview">

--- a/src/components/shelves/shelves.scss
+++ b/src/components/shelves/shelves.scss
@@ -6,6 +6,15 @@
   margin-bottom: 18px;
 }
 
+.shelf-encoding-pane {
+  flex-basis: 60%;
+}
+
+.shelf-filter-pane {
+  flex-basis: 40%;
+  position: relative;
+}
+
 .card.shelves.preview {
   bottom: initial;
   padding-bottom: 0;

--- a/src/components/shelves/shelves.scss
+++ b/src/components/shelves/shelves.scss
@@ -1,5 +1,9 @@
 .shelf-pane {
-  margin-bottom: 20px;
+  margin-bottom: 12px;
+}
+
+.shelf-encoding-pane, .shelf-filter-pane {
+  margin-bottom: 18px;
 }
 
 .card.shelves.preview {

--- a/src/index.scss
+++ b/src/index.scss
@@ -154,14 +154,14 @@ h2 {
   font-size: 16px;
   line-height: 20px;
   font-weight: 700;
-  margin: 0 0 15px;
+  margin: 0 0 10px;
 }
 
 h3 {
   @extend .noselect;
   font-size: 14px;
   font-weight: 700;
-  margin: 0 0 10px;
+  margin: 0 0 6px;
 }
 
 h4 {


### PR DESCRIPTION
Before:
![screen shot 2016-08-31 at 6 35 16 pm](https://cloud.githubusercontent.com/assets/822034/18152330/e9136010-6fa9-11e6-9b6f-ae413f91d130.png)

After: 
![screen shot 2016-08-31 at 6 38 17 pm](https://cloud.githubusercontent.com/assets/822034/18152360/2a1d03a4-6faa-11e6-8f82-1ca264a7d65c.png)
- [x] Make existing UI in Encoding Pane more compact (the h2 and h3 margin changes make Data Pane look a bit more compact too)
- [x] Re-organize Encoding and Filter Panes
  - [x] Put Positional, Marks, Automatic under Encoding
- [x] Make Filter Pane scrollable
- [x] Test with Voyager-II
- [x] Test with PoleStar
