### PR TITLE
Add basic support for temporal filters

### DIFF
--- a/src/components/filter/filtershelves.html
+++ b/src/components/filter/filtershelves.html
@@ -38,19 +38,12 @@
     <categorical-filter
       field="field"
       filter="filter"
-      ng-if="Dataset.schema.type(field) === 'nominal' || Dataset.schema.type(field) === 'ordinal'
-    "></categorical-filter>
+      ng-if="filterType(field) === 'categorical'">
+    </categorical-filter>
     <quantitative-filter
       field="field"
       filter="filter"
-      ng-if="Dataset.schema.type(field) === 'quantitative'"
+      ng-if="filterType(field) === 'quantitative'"
     ></quantitative-filter>
-    <div
-      field="field"
-      filter="filter"
-      ng-if="Dataset.schema.type(field) === 'temporal'"
-      >
-      {{field}} is a temporal field and we do not support filter for temporal field yet.
-    </div>
   </div>
 </div>

--- a/src/components/filter/filtershelves.js
+++ b/src/components/filter/filtershelves.js
@@ -7,7 +7,7 @@
  * # fieldInfo
  */
 angular.module('vlui')
-  .directive('filterShelves', function (FilterManager, Dataset) {
+  .directive('filterShelves', function (FilterManager, Dataset, vl) {
     return {
       templateUrl: 'components/filter/filtershelves.html',
       restrict: 'E',
@@ -19,6 +19,19 @@ angular.module('vlui')
         scope.filterManager = FilterManager;
         scope.clearFilter = clearFilter;
         scope.removeFilter = removeFilter;
+        scope.filterType = filterType;
+
+        function filterType(field) {
+          switch (Dataset.schema.type(field)) {
+            case 'nominal':
+            case 'ordinal':
+              return 'categorical';
+            case 'quantitative':
+              return 'quantitative';
+            case 'temporal':
+              return vl.timeUnit.defaultScaleType(field) === 'ordinal' ? 'categorical' : 'quantitative';
+          }
+        };
 
         function clearFilter(field) {
           FilterManager.reset();

--- a/src/components/filter/quantitativefilter.html
+++ b/src/components/filter/quantitativefilter.html
@@ -1,12 +1,12 @@
 <div>
   <div>
-    <span class="right domain-label">{{domainMax}}</span>
-    <span class="domain-label">{{domainMin}}</span>
+    <span class="right domain-label">{{domainMax | timeUnitFilter}}</span>
+    <span class="domain-label">{{domainMin | timeUnitFilter}}</span>
   </div>
   <div range-slider min="domainMin" max="domainMax"
     model-min="localMin" model-max="localMax"
     show-values="true" attach-handle-values="true"
-    on-handle-up="updateRange()">
+    on-handle-up="updateRange()" filter="timeUnitFilter">
   </div>
 </div>
 

--- a/src/components/filter/quantitativefilter.html
+++ b/src/components/filter/quantitativefilter.html
@@ -1,12 +1,12 @@
 <div>
   <div>
-    <span class="right domain-label">{{domainMax | timeUnitFilter}}</span>
-    <span class="domain-label">{{domainMin | timeUnitFilter}}</span>
+    <span class="right domain-label">{{domainMax}}</span>
+    <span class="domain-label">{{domainMin}}</span>
   </div>
   <div range-slider min="domainMin" max="domainMax"
     model-min="localMin" model-max="localMax"
     show-values="true" attach-handle-values="true"
-    on-handle-up="updateRange()" filter="timeUnitFilter">
+    on-handle-up="updateRange()">
   </div>
 </div>
 

--- a/src/components/filter/quantitativefilter.html
+++ b/src/components/filter/quantitativefilter.html
@@ -3,9 +3,10 @@
     <span class="right domain-label">{{domainMax}}</span>
     <span class="domain-label">{{domainMin}}</span>
   </div>
-  <div range-slider min="domainMin"" max="domainMax" 
-    model-min="filter.range[0]" model-max="filter.range[1]"
-    show-values="true" attach-handle-values="true">
+  <div range-slider min="domainMin" max="domainMax"
+    model-min="localMin" model-max="localMax"
+    show-values="true" attach-handle-values="true"
+    on-handle-up="updateRange()">
   </div>
 </div>
 

--- a/src/components/filter/quantitativefilter.js
+++ b/src/components/filter/quantitativefilter.js
@@ -30,6 +30,12 @@ angular.module('vlui')
           scope.$apply();
         };
 
+        if (Dataset.schema.type(scope.field) === 'temporal') {
+          // convert dates to numerical types
+          scope.domainMin = (new Date(scope.domainMin)).getTime();
+          scope.domainMax = (new Date(scope.domainMax)).getTime();
+        }
+
         var unwatchRange = scope.$watch('filter.range', function(range, oldRange) {
           if (!oldRange || !range || (range === oldRange)) return; // skip first time
           Logger.logInteraction(Logger.actions.FILTER_CHANGE, scope.field, scope.filter);
@@ -40,5 +46,21 @@ angular.module('vlui')
           unwatchRange();
         });
       }
+    };
+  });
+
+// for formatting dates according to the selected timeUnit (just for display purposes)
+angular.module('vlui')
+  .filter('timeUnitFilter', function() {
+    return function(dateNumber) {
+      var timeUnit = 'year'; // testing purposes
+      var date = new Date(dateNumber);
+      switch (timeUnit) {
+        case 'year':
+          return date.getFullYear();
+        case 'date':
+          return date.getDate();
+      }
+      return new Date(dateNumber);
     };
   });

--- a/src/components/filter/quantitativefilter.js
+++ b/src/components/filter/quantitativefilter.js
@@ -20,6 +20,14 @@ angular.module('vlui')
         var domain = Dataset.domain(scope.field);
         scope.domainMin = domain[0];
         scope.domainMax = domain[1];
+
+        // don't update until range slider handle released
+        scope.localMin = scope.filter.range[0];
+        scope.localMax = scope.filter.range[1];
+        scope.updateRange = function() {
+          scope.filter.range[0] = scope.localMin;
+          scope.filter.range[1] = scope.localMax;
+        };
       }
     };
   });

--- a/src/components/filter/quantitativefilter.js
+++ b/src/components/filter/quantitativefilter.js
@@ -27,6 +27,7 @@ angular.module('vlui')
         scope.updateRange = function() {
           scope.filter.range[0] = scope.localMin;
           scope.filter.range[1] = scope.localMax;
+          scope.$apply();
         };
       }
     };

--- a/src/components/filter/quantitativefilter.js
+++ b/src/components/filter/quantitativefilter.js
@@ -41,17 +41,17 @@ angular.module('vlui')
   });
 
 // for formatting dates according to the selected timeUnit (just for display purposes)
-angular.module('vlui')
-  .filter('timeUnitFilter', function() {
-    return function(dateNumber) {
-      var timeUnit = 'year'; // testing purposes
-      var date = new Date(dateNumber);
-      switch (timeUnit) {
-        case 'year':
-          return date.getFullYear();
-        case 'date':
-          return date.getDate();
-      }
-      return new Date(dateNumber);
-    };
-  });
+// angular.module('vlui')
+//   .filter('timeUnitFilter', function() {
+//     return function(dateNumber) {
+//       var timeUnit = 'year'; // testing purposes
+//       var date = new Date(dateNumber);
+//       switch (timeUnit) {
+//         case 'year':
+//           return date.getFullYear();
+//         case 'date':
+//           return date.getDate();
+//       }
+//       return new Date(dateNumber);
+//     };
+//   });


### PR DESCRIPTION
Allow users to filter temporal field types. Does not yet allow for specific timeUnit filtering.

Part of https://github.com/uwdata/voyager2/issues/188
