### PR TITLE
Fix filter pane CSS

### DIFF
--- a/src/components/filter/filtershelves.html
+++ b/src/components/filter/filtershelves.html
@@ -1,6 +1,6 @@
 <a class="right"  ng-click="clearFilter()"><i class="fa fa-eraser"></i> Clear</a>
 <h2>Filter</h2>
-<div class="filter-scroll-y-container">
+<div class="filter-scroll-y-container scroll-y no-scroll-x">
   <div class="shelf-group"
     ng-repeat="(field, filter) in filterManager.filterIndex"
     ng-if="filter.enabled"

--- a/src/components/filter/filtershelves.scss
+++ b/src/components/filter/filtershelves.scss
@@ -1,5 +1,4 @@
 .filter-scroll-y-container {
-  overflow-y: scroll;
   position: absolute;
   top: 30px;
   bottom: 0;

--- a/src/components/shelves/shelves.scss
+++ b/src/components/shelves/shelves.scss
@@ -2,16 +2,12 @@
   margin-bottom: 12px;
 }
 
-.shelf-encoding-pane, .shelf-filter-pane {
+.shelf-encoding-pane {
   margin-bottom: 18px;
 }
 
-.shelf-encoding-pane {
-  flex-basis: 60%;
-}
-
 .shelf-filter-pane {
-  flex-basis: 40%;
+  flex-grow: 1;
   position: relative;
 }
 

--- a/src/index.scss
+++ b/src/index.scss
@@ -380,6 +380,10 @@ h4 {
   overflow-x: scroll;
 }
 
+.no-scroll-x{
+  overflow-x: hidden;
+}
+
 .scroll-xy{
   @extend .persist-scroll;
   overflow-y: scroll;


### PR DESCRIPTION
I see a strange empty white scroll bar in filter pane this morning, and realized filter pane is not aligned correctly on a larger screen. This is a PR to fix these things.
- [x] Use `.scroll-y` class seems to remove the ugly empty white scroll bar, and it's more consistent with the other scroll bars in the UI
- [x] Better align encoding pane and filter pane. It used to be always 60% and 40%, now it's `flex-grow` 0 and 1. So the filter pane will always follow the encoding pane (no empty space in between) and the filter pane will take any remaining screen height.
- [x] Tested with Voyager and PoleStar
- [x] Tested on small (laptop) screen and large (monitor) screen
