### PR TITLE
Hide belowFold functions and "more" & "less" toggles in function select

### DIFF
--- a/src/components/functionselect/functionselect.html
+++ b/src/components/functionselect/functionselect.html
@@ -52,7 +52,7 @@
   </div>
 
   <!-- more and less toggles -->
-  <div ng-hide="func.isCount || func.list.belowFold.length == 0"
+  <div ng-hide="hideMoreFn || func.isCount || func.list.belowFold.length == 0"
     class="expand-collapse">
     <a ng-click="showAllFunctions=!showAllFunctions">
       <span ng-show="!showAllFunctions"> more <i class="fa fa-angle-down" aria-hidden="true"></i> </span>

--- a/src/components/functionselect/functionselect.js
+++ b/src/components/functionselect/functionselect.js
@@ -13,6 +13,8 @@ angular.module('vlui')
       link: function(scope /*,element, attrs*/) {
         var BIN='bin', COUNT='count', maxbins;
 
+        scope.hideMoreFn = consts.hideMoreFn;
+
         scope.func = {
           selected: undefined,
           checked: {undefined: true},

--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,7 @@ angular.module('vlui', [
     logLevel: 'INFO',
     logPrintLevel: 'INFO',
     logToWebSql: false, // in user studies, set this to true
+    hideMoreFn: true, // hide belowFold functions and "more" & "less" toggles in functionselect during user studies
     defaultConfigSet: 'large',
     appId: 'vlui',
     // embedded polestar and voyager with known data


### PR DESCRIPTION
- [x] Hide belowFold functions and "more" & "less" toggles in function select
- [x] `consts.hideMoreFn` to turn this on and off
- [x] Tested with Voyager-II and PoleStar
