### PR TITLE
Format temporal filter dates as year-month-date

### DIFF
--- a/src/components/filter/quantitativefilter.html
+++ b/src/components/filter/quantitativefilter.html
@@ -1,12 +1,12 @@
 <div>
   <div>
-    <span class="right domain-label">{{domainMax}}</span>
-    <span class="domain-label">{{domainMin}}</span>
+    <span class="right domain-label">{{domainMax | timeUnitFilter}}</span>
+    <span class="domain-label">{{domainMin | timeUnitFilter}}</span>
   </div>
   <div range-slider min="domainMin" max="domainMax"
     model-min="localMin" model-max="localMax"
     show-values="true" attach-handle-values="true"
-    on-handle-up="updateRange()">
+    on-handle-up="updateRange()" filter="timeUnitFilter">
   </div>
 </div>
 

--- a/src/components/filter/quantitativefilter.js
+++ b/src/components/filter/quantitativefilter.js
@@ -41,17 +41,10 @@ angular.module('vlui')
   });
 
 // for formatting dates according to the selected timeUnit (just for display purposes)
-// angular.module('vlui')
-//   .filter('timeUnitFilter', function() {
-//     return function(dateNumber) {
-//       var timeUnit = 'year'; // testing purposes
-//       var date = new Date(dateNumber);
-//       switch (timeUnit) {
-//         case 'year':
-//           return date.getFullYear();
-//         case 'date':
-//           return date.getDate();
-//       }
-//       return new Date(dateNumber);
-//     };
-//   });
+angular.module('vlui')
+  .filter('timeUnitFilter', function() {
+    return function(dateNumber) {
+      var date = new Date(dateNumber);
+      return date.getFullYear() + '-' + date.getMonth() + '-' + date.getDate();
+    };
+  });


### PR DESCRIPTION
Apply an Angular filter to temporal filter sliders so that the dates are displayed in the year-month-date format instead of as a timestamp.
