### PR TITLE
Textarea now autofocuses when create a new bookmark

### DIFF
--- a/src/components/vlplotgroup/vlplotgroup.js
+++ b/src/components/vlplotgroup/vlplotgroup.js
@@ -88,6 +88,10 @@ angular.module('vlui')
           }
           else {
             Bookmarks.add(chart, scope.listTitle);
+
+            $timeout(function () {
+                element.children()[2].focus();
+            });
           }
         };
 

--- a/src/components/vlplotgroup/vlplotgroup.js
+++ b/src/components/vlplotgroup/vlplotgroup.js
@@ -90,7 +90,7 @@ angular.module('vlui')
             Bookmarks.add(chart, scope.listTitle);
 
             $timeout(function () {
-                element.children()[2].focus();
+                element.find('textarea.annotation')[0].focus();
             });
           }
         };


### PR DESCRIPTION
Fix to Voyager 2 issue number 251 (When bookmark is enabled, the textbox should be focused).